### PR TITLE
Flush the queue to have the right data for inference

### DIFF
--- a/run_online.py
+++ b/run_online.py
@@ -197,6 +197,10 @@ def main():
 
     label_queue = Queue()
     shutdown_event = threading.Event()
+    
+    # Flush synchronization for real-time inference
+    flush_request = threading.Event()
+    flush_complete = threading.Event()
 
     def shutdown(sig, frame):
         if shutdown_event.is_set():
@@ -225,7 +229,8 @@ def main():
     # Label thread
     label_thread = threading.Thread(
         target=label_loop,
-        args=(recorder, labeler, trainer.retriever, label_queue, inference_buffer, sleepwalk_active),
+        args=(recorder, labeler, trainer.retriever, label_queue, inference_buffer, sleepwalk_active,
+              flush_request, flush_complete),
         daemon=True,
     )
     label_thread.start()
@@ -237,7 +242,11 @@ def main():
             args=(predictor, inference_buffer, trainer, recorder,
                   args.past_len, args.future_len, tokenizer,
                   args.predict_every_n_seconds, args.reward_llm, overlay, walker),
-            kwargs={"num_imgs_per_sample": args.num_imgs_per_sample},
+            kwargs={
+                "num_imgs_per_sample": args.num_imgs_per_sample,
+                "flush_request": flush_request,
+                "flush_complete": flush_complete,
+            },
             daemon=True,
         )
         inference_thread.start()

--- a/src/powernap/inference/loop.py
+++ b/src/powernap/inference/loop.py
@@ -4,6 +4,7 @@ import logging
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 
 from powernap.longnap.trainer_utils import build_actions_block
 
@@ -17,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 def inference_loop(predictor, inference_buffer, trainer, recorder,
                    past_len, future_len, processor, predict_interval,
-                   reward_llm, overlay, walker, num_imgs_per_sample=0):
+                   reward_llm, overlay, walker, num_imgs_per_sample=0,
+                   flush_request=None, flush_complete=None):
 
     executor = ThreadPoolExecutor(max_workers=8)
     pending_predictions = []  # (future, buffer_pos, seq)
@@ -48,11 +50,45 @@ def inference_loop(predictor, inference_buffer, trainer, recorder,
 
         if (is_visible and not prediction_submitted and predictor.model_path
                 and cur_buffer_len >= past_len):
+            
+            # Capture timestamp BEFORE flush - exclude events after hotkey press
+            # This prevents the Ctrl+H keypress from biasing the prediction
+            cutoff_ts = time.time()
+            
+            # Request flush of pending chunks for fresh data
+            if flush_request is not None and flush_complete is not None:
+                if overlay:
+                    overlay.update_flushing()
+                
+                flush_complete.clear()
+                flush_request.set()
+                
+                # Wait for flush to complete (with timeout)
+                if not flush_complete.wait(timeout=45.0):
+                    print("[inference] flush timed out, using stale buffer")
+            
+            # Re-check buffer length after flush (may have new items)
+            cur_buffer_len = buffer_trim_offset + len(inference_buffer)
             buffer_pos = cur_buffer_len
             prediction_seq += 1
 
             sampling_client = trainer.sampling_client
-            buffer_snapshot = list(inference_buffer[-past_len:])
+            
+            # Filter buffer to only include items BEFORE the hotkey was pressed
+            # This prevents the Ctrl+H keypress from biasing the prediction
+            filtered_buffer = [
+                item for item in inference_buffer
+                if datetime.strptime(item["start_time"], "%Y-%m-%d_%H-%M-%S-%f").timestamp() < cutoff_ts
+            ]
+            
+            # Skip if not enough context after filtering
+            if len(filtered_buffer) < past_len:
+                print(f"[inference] not enough pre-cutoff items ({len(filtered_buffer)}/{past_len}), skipping")
+                prediction_submitted = True  # Don't retry immediately
+                time.sleep(1)
+                continue
+            
+            buffer_snapshot = filtered_buffer[-past_len:]
 
             future = executor.submit(
                 predictor.predict_from_snapshot,

--- a/src/powernap/inference/overlay.py
+++ b/src/powernap/inference/overlay.py
@@ -129,17 +129,57 @@ class ActionOverlay:
         """Build a styled 'not ready' message."""
         import AppKit
 
-        font = AppKit.NSFont.systemFontOfSize_weight_(12, AppKit.NSFontWeightMedium)
-        color = AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(
+        result = AppKit.NSMutableAttributedString.alloc().init()
+
+        # ── Header ──
+        header_font = AppKit.NSFont.systemFontOfSize_weight_(
+            13, AppKit.NSFontWeightBold
+        )
+        header_color = AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(
             1.0, 1.0, 1.0, 0.5
         )
-        attrs = {
-            AppKit.NSFontAttributeName: font,
-            AppKit.NSForegroundColorAttributeName: color,
+        header_attrs = {
+            AppKit.NSFontAttributeName: header_font,
+            AppKit.NSForegroundColorAttributeName: header_color,
         }
-        return AppKit.NSAttributedString.alloc().initWithString_attributes_(
-            "Still labeling data\u2026\nTry again in a moment.", attrs
+        header = AppKit.NSAttributedString.alloc().initWithString_attributes_(
+            "Not Ready\n", header_attrs
         )
+        result.appendAttributedString_(header)
+
+        # ── Separator ──
+        sep_font = AppKit.NSFont.systemFontOfSize_weight_(
+            6, AppKit.NSFontWeightRegular
+        )
+        sep_color = AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(
+            1.0, 1.0, 1.0, 0.25
+        )
+        sep_attrs = {
+            AppKit.NSFontAttributeName: sep_font,
+            AppKit.NSForegroundColorAttributeName: sep_color,
+        }
+        separator = AppKit.NSAttributedString.alloc().initWithString_attributes_(
+            "\u2500" * 46 + "\n\n", sep_attrs
+        )
+        result.appendAttributedString_(separator)
+
+        # ── Description ──
+        body_font = AppKit.NSFont.systemFontOfSize_weight_(
+            11.5, AppKit.NSFontWeightRegular
+        )
+        body_color = AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(
+            1.0, 1.0, 1.0, 0.5
+        )
+        body_attrs = {
+            AppKit.NSFontAttributeName: body_font,
+            AppKit.NSForegroundColorAttributeName: body_color,
+        }
+        body = AppKit.NSAttributedString.alloc().initWithString_attributes_(
+            "Still labeling data\u2026\nTry again in a moment.", body_attrs
+        )
+        result.appendAttributedString_(body)
+
+        return result
 
     @staticmethod
     def _build_flushing_string():

--- a/src/powernap/inference/overlay.py
+++ b/src/powernap/inference/overlay.py
@@ -16,7 +16,7 @@ class ActionOverlay:
         self._scroll_view = None
         self._window = None
         self._app = None
-        self._visible = True
+        self._visible = False  # Start hidden, user toggles with Ctrl+H
         self._monitor = None
         self._screen_frame = None
         self._sleepwalk_callback = None
@@ -86,7 +86,8 @@ class ActionOverlay:
         attr_str = self._make_waiting_string()
         text_view.textStorage().setAttributedString_(attr_str)
 
-        window.orderFrontRegardless()
+        # Don't show window at startup - user toggles with Ctrl+H
+        # window.orderFrontRegardless()
 
         self._window = window
         self._scroll_view = scroll_view
@@ -125,7 +126,7 @@ class ActionOverlay:
 
     @staticmethod
     def _make_waiting_string():
-        """Build a styled 'waiting' message."""
+        """Build a styled 'not ready' message."""
         import AppKit
 
         font = AppKit.NSFont.systemFontOfSize_weight_(12, AppKit.NSFontWeightMedium)
@@ -137,8 +138,65 @@ class ActionOverlay:
             AppKit.NSForegroundColorAttributeName: color,
         }
         return AppKit.NSAttributedString.alloc().initWithString_attributes_(
-            "Waiting for predictions\u2026", attrs
+            "Still labeling data\u2026\nTry again in a moment.", attrs
         )
+
+    @staticmethod
+    def _build_flushing_string():
+        """Build a styled string showing data flush in progress."""
+        import AppKit
+
+        result = AppKit.NSMutableAttributedString.alloc().init()
+
+        # ── Header ──
+        header_font = AppKit.NSFont.systemFontOfSize_weight_(
+            13, AppKit.NSFontWeightBold
+        )
+        header_color = AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(
+            0.55, 0.78, 0.95, 1.0  # blue
+        )
+        header_attrs = {
+            AppKit.NSFontAttributeName: header_font,
+            AppKit.NSForegroundColorAttributeName: header_color,
+        }
+        header = AppKit.NSAttributedString.alloc().initWithString_attributes_(
+            "Syncing Data\u2026\n", header_attrs
+        )
+        result.appendAttributedString_(header)
+
+        # ── Separator ──
+        sep_font = AppKit.NSFont.systemFontOfSize_weight_(
+            6, AppKit.NSFontWeightRegular
+        )
+        sep_color = AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(
+            1.0, 1.0, 1.0, 0.25
+        )
+        sep_attrs = {
+            AppKit.NSFontAttributeName: sep_font,
+            AppKit.NSForegroundColorAttributeName: sep_color,
+        }
+        separator = AppKit.NSAttributedString.alloc().initWithString_attributes_(
+            "\u2500" * 46 + "\n\n", sep_attrs
+        )
+        result.appendAttributedString_(separator)
+
+        # ── Description ──
+        body_font = AppKit.NSFont.systemFontOfSize_weight_(
+            11.5, AppKit.NSFontWeightRegular
+        )
+        body_color = AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(
+            1.0, 1.0, 1.0, 0.7
+        )
+        body_attrs = {
+            AppKit.NSFontAttributeName: body_font,
+            AppKit.NSForegroundColorAttributeName: body_color,
+        }
+        body = AppKit.NSAttributedString.alloc().initWithString_attributes_(
+            "Labeling recent activity for fresh predictions\u2026", body_attrs
+        )
+        result.appendAttributedString_(body)
+
+        return result
 
     @staticmethod
     def _build_attributed_string(text):
@@ -375,6 +433,18 @@ class ActionOverlay:
         if self._text_view is None:
             return
         attr_str = self._build_attributed_string(text)
+        from PyObjCTools import AppHelper
+
+        def _on_main():
+            self._do_update(attr_str)
+
+        AppHelper.callAfter(_on_main)
+
+    def update_flushing(self):
+        """Update overlay to show data flush in progress."""
+        if self._text_view is None:
+            return
+        attr_str = self._build_flushing_string()
         from PyObjCTools import AppHelper
 
         def _on_main():

--- a/src/powernap/napsack/pipeline.py
+++ b/src/powernap/napsack/pipeline.py
@@ -13,12 +13,15 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def label_loop(recorder, labeler, retriever, label_queue, inference_buffer, sleepwalk_active):
+def label_loop(recorder, labeler, retriever, label_queue, inference_buffer, sleepwalk_active,
+               flush_request=None, flush_complete=None):
     """Label incoming screen recordings by accumulating into video chunks."""
-    asyncio.run(_async_label_loop(recorder, labeler, retriever, label_queue, inference_buffer, sleepwalk_active))
+    asyncio.run(_async_label_loop(recorder, labeler, retriever, label_queue, inference_buffer, sleepwalk_active,
+                                   flush_request, flush_complete))
 
 
-async def _async_label_loop(recorder, labeler, retriever, label_queue, inference_buffer, sleepwalk_active):
+async def _async_label_loop(recorder, labeler, retriever, label_queue, inference_buffer, sleepwalk_active,
+                            flush_request=None, flush_complete=None):
     """Async label loop: accumulates aggregations into chunks, labels via video.
     
     Uses parallel chunk processing while preserving chronological output order.
@@ -41,6 +44,9 @@ async def _async_label_loop(recorder, labeler, retriever, label_queue, inference
     
     fetching = True
     fetch_task = None
+    
+    # Track flush task specifically for signaling completion
+    flush_task = None
     
     while fetching or pending_chunks or chunk_buffer:
         # Start a fetch if we aren't already fetching
@@ -70,6 +76,22 @@ async def _async_label_loop(recorder, labeler, retriever, label_queue, inference
         except asyncio.CancelledError:
             break
         
+        # Handle flush request from inference
+        if flush_request is not None and flush_request.is_set():
+            flush_request.clear()  # Clear immediately to avoid re-triggering
+            
+            if chunk_buffer:
+                # Submit partial chunk for immediate labeling
+                chunk_count += 1
+                print(f"[label] flush requested: submitting partial chunk #{chunk_count} with {len(chunk_buffer)} aggregations")
+                task = asyncio.create_task(labeler.alabel_chunk(chunk_buffer.copy()))
+                pending_chunks.append((task, chunk_buffer.copy(), time.time()))
+                flush_task = task  # Track this specific task
+                chunk_buffer.clear()
+            elif flush_complete is not None:
+                # Nothing to flush — signal complete immediately
+                flush_complete.set()
+        
         # Handle fetch completion
         if fetch_task in done:
             agg = fetch_task.result()
@@ -96,6 +118,12 @@ async def _async_label_loop(recorder, labeler, retriever, label_queue, inference
             task, chunk_aggs, t0 = pending_chunks.popleft()
             labeled_list = task.result()
             latency = time.time() - t0
+            
+            # Check if this was the flush task
+            if flush_task is not None and task is flush_task:
+                if flush_complete is not None:
+                    flush_complete.set()
+                flush_task = None  # Clear reference to avoid memory leak
             
             # Emit each label
             for labeled in labeled_list:
@@ -127,5 +155,9 @@ async def _async_label_loop(recorder, labeler, retriever, label_queue, inference
                         )
                     
                     wandb.log(log)
+    
+    # On loop exit, ensure any waiting inference thread is unblocked
+    if flush_complete is not None:
+        flush_complete.set()
     
     print(f"[label] finished: {label_count} labels, {chunk_count} chunks, {skip_count} skipped")


### PR DESCRIPTION
Rough problem is that if you call the overlay, then it might actually be using a sample from 60-120 seconds ago because it's not yet in the inference buffer. We want to flush the buffer right away to have it ready for inference.

Summary
- Add flush synchronization for real-time inference: Introduces flush_request and flush_complete threading events that allow the inference loop to request the label loop to immediately process pending chunks, ensuring predictions use the freshest available data
- Prevent hotkey press from biasing predictions: Filters the inference buffer to exclude events after the hotkey press timestamp, so the Ctrl+H keypress itself doesn't influence what gets predicted
- Improve overlay UX: Overlay now starts hidden by default (toggled with Ctrl+H), shows informative "Not Ready" and "Syncing Data…" states with styled headers/separators, and provides contextual feedback during data flush