### PR TITLE
Kanishk/agent status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 python-sdk
+.claude*
 
 all_labels.jsonl
 node_modules/
@@ -243,3 +244,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Claude Code local state (worktrees, hooks, settings)
+.claude/

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable
 
 import httpx
 import litellm
@@ -27,11 +28,13 @@ class Agent:
         max_rounds: int = 30,
         web_search: bool | dict = False,
         api_key: str | None = None,
+        on_round: Callable[[int, int], None] | None = None,
     ):
         self.model = model
         self.api_key = api_key or None
         self.system_prompt = system_prompt
         self.max_rounds = max_rounds
+        self.on_round = on_round
         self._compact = compact_tool
         self._bg = bg_manager
         if web_search is True:
@@ -54,6 +57,12 @@ class Agent:
         rounds_without_plan = 0
 
         for round_num in range(self.max_rounds):
+            if self.on_round:
+                try:
+                    self.on_round(round_num + 1, self.max_rounds)
+                except Exception as e:
+                    print(f"  [on_round callback error] {e}")
+
             # compression
             if self._compact:
                 self._compact.microcompact(messages)

--- a/src/apps/memory/ingest.py
+++ b/src/apps/memory/ingest.py
@@ -54,7 +54,7 @@ def _new_seeker_conversations(logs_dir: str, since: datetime | None) -> list[str
     ]
 
 
-def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
+def run(logs_dir: str, model: str, api_key: str | None = None, on_round=None) -> str:
     logs_path = Path(logs_dir).resolve()
     logs_dir = str(logs_path)
     memory_dir = logs_path / "memory"
@@ -93,6 +93,7 @@ def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
 
     agent, _ = build_agent(model, logs_dir, api_key=api_key)
     agent.max_rounds = 200
+    agent.on_round = on_round
     result = agent.run([{"role": "user", "content": instruction}])
 
     write_checkpoint(checkpoint_path)

--- a/src/apps/memory/lint.py
+++ b/src/apps/memory/lint.py
@@ -17,7 +17,7 @@ from apps.moments._incremental import read_checkpoint, write_checkpoint
 LINT_TEMPLATE = (Path(__file__).parent / "prompts" / "lint.txt").read_text()
 
 
-def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
+def run(logs_dir: str, model: str, api_key: str | None = None, on_round=None) -> str:
     logs_path = Path(logs_dir).resolve()
     memory_dir = logs_path / "memory"
 
@@ -33,6 +33,7 @@ def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
 
     agent, _ = build_agent(model, str(logs_path), api_key=api_key)
     agent.max_rounds = 100
+    agent.on_round = on_round
     result = agent.run([{"role": "user", "content": instruction}])
 
     write_checkpoint(checkpoint_path)

--- a/src/apps/memory/service.py
+++ b/src/apps/memory/service.py
@@ -26,10 +26,10 @@ class MemoryIngest:
         self.model = model
         self.api_key = api_key
 
-    def run(self) -> str:
+    def run(self, on_round=None) -> str:
         """Read new logs and update wiki pages. Blocking."""
         from apps.memory.ingest import run as ingest_run
-        return ingest_run(self.logs_dir, model=self.model, api_key=self.api_key)
+        return ingest_run(self.logs_dir, model=self.model, api_key=self.api_key, on_round=on_round)
 
 
 class MemoryLint:
@@ -40,10 +40,10 @@ class MemoryLint:
         self.model = model
         self.api_key = api_key
 
-    def run(self) -> str:
+    def run(self, on_round=None) -> str:
         """Lint the wiki. Blocking."""
         from apps.memory.lint import run as lint_run
-        return lint_run(self.logs_dir, model=self.model, api_key=self.api_key)
+        return lint_run(self.logs_dir, model=self.model, api_key=self.api_key, on_round=on_round)
 
 
 def _read_last_run(p: Path) -> datetime | None:
@@ -88,18 +88,22 @@ async def run_memory_service(state) -> None:
             api_key = cfg.memory_agent_api_key or cfg.resolve_api_key("agent_api_key")
 
             try:
-                await state.broadcast_activity("memory", "Ingesting memories…")
+                ingest_msg = "Ingesting memories…"
+                await state.broadcast_activity("memory", ingest_msg)
+                on_round = state.make_round_callback("memory", ingest_msg)
                 logger.info("Memory: running ingest")
-                await asyncio.to_thread(MemoryIngest(logs_dir, model, api_key).run)
+                await asyncio.to_thread(MemoryIngest(logs_dir, model, api_key).run, on_round=on_round)
                 logger.info("Memory: ingest complete")
                 await state.broadcast("memory_updated", {})
 
                 lint_last_run = _read_last_run(lint_last_run_file)
                 should_lint = lint_last_run is None or (datetime.now() - lint_last_run) >= timedelta(days=6)
                 if should_lint:
-                    await state.broadcast_activity("memory", "Auditing memories…")
+                    lint_msg = "Auditing memories…"
+                    await state.broadcast_activity("memory", lint_msg)
+                    lint_on_round = state.make_round_callback("memory", lint_msg)
                     logger.info("Memory: running lint (weekly)")
-                    await asyncio.to_thread(MemoryLint(logs_dir, model, api_key).run)
+                    await asyncio.to_thread(MemoryLint(logs_dir, model, api_key).run, on_round=lint_on_round)
                     lint_last_run_file.parent.mkdir(parents=True, exist_ok=True)
                     lint_last_run_file.write_text(datetime.now().isoformat())
                     logger.info("Memory: lint complete")

--- a/src/apps/memory/service.py
+++ b/src/apps/memory/service.py
@@ -6,16 +6,17 @@ import argparse
 import os
 import asyncio
 import logging
-import re
 from datetime import datetime, timedelta
 from pathlib import Path
 
 from server.feature_flags import is_enabled
 from agent.builder import _ensure_sandbox_async
-from apps.moments.scheduler import _next_run_time, _parse_time
+from apps.moments.scheduler import is_due
 from server.cost_tracker import init_cost_tracking
 
 logger = logging.getLogger(__name__)
+
+SCAN_INTERVAL = 60  # seconds between schedule checks
 
 class MemoryIngest:
     """Ingests new activity logs into the personal knowledge wiki."""
@@ -56,75 +57,57 @@ def _read_last_run(p: Path) -> datetime | None:
 
 
 async def run_memory_service(state) -> None:
-    """Background task: run ingest daily and lint weekly.
-
-    If the scheduled time has already passed today but we haven't run yet
-    (e.g. the computer was off at 3am), run immediately on wake.
+    """Background task: poll every SCAN_INTERVAL and run ingest whenever the
+    most recent scheduled occurrence hasn't completed yet. Lint runs alongside
+    ingest if its own 6-day cooldown has elapsed.
     """
 
     logger.info("Memory wiki service started")
 
+    logs_dir = str(Path(state.config.log_dir).resolve())
+    last_run_file = Path(logs_dir) / "memory" / ".memory_last_run"
+    lint_last_run_file = Path(logs_dir) / "memory" / ".memory_lint_last_run"
+
+    # Pre-initialize sandbox on the event-loop thread (signal handlers
+    # can only be registered here, not inside the worker thread).
+    await _ensure_sandbox_async([logs_dir])
+
     while True:
         try:
-            schedule = getattr(state.config, "memory_schedule", "daily at 3am")
-            next_run = _next_run_time(schedule, "daily")
-            if next_run is None:
-                logger.warning("Cannot parse memory schedule %r, retrying in 1h", schedule)
-                await asyncio.sleep(3600)
-                continue
-
-            # Check if we missed today's run
-            now = datetime.now()
-            time_match = re.search(r"(?:at\s+)?(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)", schedule.lower())
-            scheduled_time = _parse_time(time_match.group(1)) if time_match else None
-            today_target = datetime.combine(now.date(), scheduled_time) if scheduled_time else None
-            last_run_file = Path(state.config.log_dir).resolve() / "memory" / ".memory_last_run"
-            last_run = _read_last_run(last_run_file)
-            missed = (
-                today_target is not None
-                and now > today_target
-                and (last_run is None or last_run < today_target)
-            )
-
-            if missed:
-                logger.info("Missed scheduled memory ingest at %s, running now", today_target)
-            else:
-                delay = (next_run - now).total_seconds()
-                logger.info("Next memory ingest at %s (in %.0fs)", next_run, delay)
-                await asyncio.sleep(delay)
+            await asyncio.sleep(SCAN_INTERVAL)
 
             if not (is_enabled(state.config, "memory") and state.config.memory_enabled):
                 continue
 
+            schedule = getattr(state.config, "memory_schedule", "daily at 3am")
+            if not is_due(schedule, "daily", _read_last_run(last_run_file)):
+                continue
+
             cfg = state.config
-            logs_dir = str(Path(cfg.log_dir).resolve())
             model = cfg.memory_agent_model
             api_key = cfg.memory_agent_api_key or cfg.resolve_api_key("agent_api_key")
 
-            # Pre-initialize sandbox on the event-loop thread (signal handlers
-            # can only be registered here, not inside the worker thread).
-            await _ensure_sandbox_async([logs_dir])
+            try:
+                await state.broadcast_activity("memory", "Ingesting memories…")
+                logger.info("Memory: running ingest")
+                await asyncio.to_thread(MemoryIngest(logs_dir, model, api_key).run)
+                logger.info("Memory: ingest complete")
+                await state.broadcast("memory_updated", {})
 
-            # Always run ingest
-            logger.info("Memory: running ingest")
-            await asyncio.to_thread(MemoryIngest(logs_dir, model, api_key).run)
-            logger.info("Memory: ingest complete")
-            await state.broadcast("memory_updated", {})
+                lint_last_run = _read_last_run(lint_last_run_file)
+                should_lint = lint_last_run is None or (datetime.now() - lint_last_run) >= timedelta(days=6)
+                if should_lint:
+                    await state.broadcast_activity("memory", "Auditing memories…")
+                    logger.info("Memory: running lint (weekly)")
+                    await asyncio.to_thread(MemoryLint(logs_dir, model, api_key).run)
+                    lint_last_run_file.parent.mkdir(parents=True, exist_ok=True)
+                    lint_last_run_file.write_text(datetime.now().isoformat())
+                    logger.info("Memory: lint complete")
 
-            # Run lint if last lint was >6 days ago
-            lint_last_run_file = Path(logs_dir) / "memory" / ".memory_lint_last_run"
-            lint_last_run = _read_last_run(lint_last_run_file)
-            should_lint = lint_last_run is None or (now - lint_last_run) >= timedelta(days=6)
-
-            if should_lint:
-                logger.info("Memory: running lint (weekly)")
-                await asyncio.to_thread(MemoryLint(logs_dir, model, api_key).run)
-                lint_last_run_file.parent.mkdir(parents=True, exist_ok=True)
-                lint_last_run_file.write_text(datetime.now().isoformat())
-                logger.info("Memory: lint complete")
-
-            last_run_file.parent.mkdir(parents=True, exist_ok=True)
-            last_run_file.write_text(datetime.now().isoformat())
+                last_run_file.parent.mkdir(parents=True, exist_ok=True)
+                last_run_file.write_text(datetime.now().isoformat())
+            finally:
+                await state.broadcast_activity(None)
 
         except asyncio.CancelledError:
             logger.info("Memory wiki service stopped")

--- a/src/apps/moments/discover.py
+++ b/src/apps/moments/discover.py
@@ -20,7 +20,7 @@ INSTRUCTION_TEMPLATE = (_PROMPTS / "discover.txt").read_text()
 INCREMENTAL_SECTION = (_PROMPTS / "discover_incremental.txt").read_text()
 
 
-def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
+def run(logs_dir: str, model: str, api_key: str | None = None, on_round=None) -> str:
     logs_path = Path(logs_dir).resolve()
     logs_dir = str(logs_path)
     checkpoint_path = logs_path / "tasks" / ".last_discovery"
@@ -48,6 +48,7 @@ def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
 
     agent, _ = build_agent(model, logs_dir, api_key=api_key)
     agent.max_rounds = 200
+    agent.on_round = on_round
     messages = [{"role": "user", "content": instruction}]
     result = agent.run(messages)
 

--- a/src/apps/moments/discovery.py
+++ b/src/apps/moments/discovery.py
@@ -101,19 +101,19 @@ async def run_moments_discovery(state) -> None:
             api_key = cfg.resolve_api_key("moments_agent_api_key")
 
             try:
-                discover_msg = "Discovering recurring moments…"
+                discover_msg = "Discovering recurring Tadas…"
                 await state.broadcast_activity("moments_discovery", discover_msg)
                 discover_cb = state.make_round_callback("moments_discovery", discover_msg)
                 logger.info("Discovery: finding recurring moments")
                 await asyncio.to_thread(MomentsDiscovery(logs_dir, model, api_key).run, on_round=discover_cb)
 
-                oneoffs_msg = "Discovering one-off moments…"
+                oneoffs_msg = "Discovering one-off Tadas…"
                 await state.broadcast_activity("moments_discovery", oneoffs_msg)
                 oneoffs_cb = state.make_round_callback("moments_discovery", oneoffs_msg)
                 logger.info("Discovery: finding one-off moments")
                 await asyncio.to_thread(OneoffsDiscovery(logs_dir, model, api_key).run, on_round=oneoffs_cb)
 
-                filter_msg = "Filtering tasks…"
+                filter_msg = "Filtering Tadas…"
                 await state.broadcast_activity("moments_discovery", filter_msg)
                 filter_cb = state.make_round_callback("moments_discovery", filter_msg)
                 logger.info("Discovery: filtering tasks")

--- a/src/apps/moments/discovery.py
+++ b/src/apps/moments/discovery.py
@@ -22,10 +22,10 @@ class MomentsDiscovery:
         self.model = model
         self.api_key = api_key
 
-    def run(self) -> str:
+    def run(self, on_round=None) -> str:
         """Analyze logs and write task files. Blocking."""
         from apps.moments.discover import run as moments_run
-        return moments_run(self.logs_dir, model=self.model, api_key=self.api_key)
+        return moments_run(self.logs_dir, model=self.model, api_key=self.api_key, on_round=on_round)
 
 
 class OneoffsDiscovery:
@@ -36,10 +36,10 @@ class OneoffsDiscovery:
         self.model = model
         self.api_key = api_key
 
-    def run(self) -> str:
+    def run(self, on_round=None) -> str:
         """Analyze logs and write one-off task files. Blocking."""
         from apps.moments.oneoffs import run as oneoffs_run
-        return oneoffs_run(self.logs_dir, model=self.model, api_key=self.api_key)
+        return oneoffs_run(self.logs_dir, model=self.model, api_key=self.api_key, on_round=on_round)
 
 
 class TaskFilter:
@@ -50,10 +50,10 @@ class TaskFilter:
         self.model = model
         self.api_key = api_key
 
-    def run(self) -> str:
+    def run(self, on_round=None) -> str:
         """Filter tasks through tada. Blocking."""
         from apps.moments.filter import run as filter_run
-        return filter_run(self.logs_dir, model=self.model, api_key=self.api_key)
+        return filter_run(self.logs_dir, model=self.model, api_key=self.api_key, on_round=on_round)
 
 
 def _read_last_run(p: Path) -> datetime | None:
@@ -101,17 +101,23 @@ async def run_moments_discovery(state) -> None:
             api_key = cfg.resolve_api_key("moments_agent_api_key")
 
             try:
-                await state.broadcast_activity("moments_discovery", "Discovering recurring moments…")
+                discover_msg = "Discovering recurring moments…"
+                await state.broadcast_activity("moments_discovery", discover_msg)
+                discover_cb = state.make_round_callback("moments_discovery", discover_msg)
                 logger.info("Discovery: finding recurring moments")
-                await asyncio.to_thread(MomentsDiscovery(logs_dir, model, api_key).run)
+                await asyncio.to_thread(MomentsDiscovery(logs_dir, model, api_key).run, on_round=discover_cb)
 
-                await state.broadcast_activity("moments_discovery", "Discovering one-off moments…")
+                oneoffs_msg = "Discovering one-off moments…"
+                await state.broadcast_activity("moments_discovery", oneoffs_msg)
+                oneoffs_cb = state.make_round_callback("moments_discovery", oneoffs_msg)
                 logger.info("Discovery: finding one-off moments")
-                await asyncio.to_thread(OneoffsDiscovery(logs_dir, model, api_key).run)
+                await asyncio.to_thread(OneoffsDiscovery(logs_dir, model, api_key).run, on_round=oneoffs_cb)
 
-                await state.broadcast_activity("moments_discovery", "Filtering tasks…")
+                filter_msg = "Filtering tasks…"
+                await state.broadcast_activity("moments_discovery", filter_msg)
+                filter_cb = state.make_round_callback("moments_discovery", filter_msg)
                 logger.info("Discovery: filtering tasks")
-                await asyncio.to_thread(TaskFilter(logs_dir, model, api_key).run)
+                await asyncio.to_thread(TaskFilter(logs_dir, model, api_key).run, on_round=filter_cb)
 
                 last_run_file.write_text(datetime.now().isoformat())
                 logger.info("Discovery pipeline complete")

--- a/src/apps/moments/discovery.py
+++ b/src/apps/moments/discovery.py
@@ -11,6 +11,8 @@ from server.feature_flags import is_enabled
 
 logger = logging.getLogger(__name__)
 
+SCAN_INTERVAL = 60  # seconds between schedule checks
+
 
 class MomentsDiscovery:
     """Discovers recurring automation tasks from activity logs."""
@@ -65,62 +67,56 @@ def _read_last_run(p: Path) -> datetime | None:
 
 
 async def run_moments_discovery(state) -> None:
-    """Background task: run the full discovery pipeline at a fixed daily time.
+    """Background task: poll every SCAN_INTERVAL and run the discovery pipeline
+    whenever the most recent scheduled occurrence hasn't completed yet.
 
-    If the scheduled time has already passed today but we haven't run yet
-    (e.g. the computer was off at 2am), run immediately on wake.
+    Polling (instead of one long sleep to the next target) catches up after
+    laptop sleep/wake and avoids drift if the schedule is edited at runtime.
     """
-    from apps.moments.scheduler import _next_run_time, _parse_time
+    from apps.moments.scheduler import is_due
 
     logger.info("Moments discovery service started")
 
+    # Signal handlers require main thread — pre-init before to_thread.
+    from agent.builder import _ensure_sandbox_async
+    logs_dir = str(Path(state.config.log_dir).resolve())
+    tada_dir = str(Path(state.config.tada_dir).resolve())
+    await _ensure_sandbox_async([logs_dir, tada_dir])
+
+    last_run_file = Path(state.config.log_dir).resolve() / ".discovery_last_run"
+
     while True:
         try:
-            schedule = getattr(state.config, "moments_discovery_schedule", "daily at 2am")
-            next_run = _next_run_time(schedule, "daily")
-            if next_run is None:
-                logger.warning("Cannot parse discovery schedule %r, retrying in 1h", schedule)
-                await asyncio.sleep(3600)
-                continue
-
-            # Check if we missed today's run (e.g. computer was off at scheduled time)
-            now = datetime.now()
-            scheduled_time = _parse_time(schedule)
-            today_target = datetime.combine(now.date(), scheduled_time) if scheduled_time else None
-            last_run_file = Path(state.config.log_dir).resolve() / ".discovery_last_run"
-            last_run = _read_last_run(last_run_file)
-            missed = (
-                today_target is not None
-                and now > today_target
-                and (last_run is None or last_run < today_target)
-            )
-
-            if missed:
-                logger.info("Missed scheduled discovery at %s, running now", today_target)
-            else:
-                delay = (next_run - now).total_seconds()
-                logger.info("Next discovery run at %s (in %.0fs)", next_run, delay)
-                await asyncio.sleep(delay)
+            await asyncio.sleep(SCAN_INTERVAL)
 
             if not (is_enabled(state.config, "moments") and state.config.moments_enabled):
                 continue
 
+            schedule = getattr(state.config, "moments_discovery_schedule", "daily at 2am")
+            if not is_due(schedule, "daily", _read_last_run(last_run_file)):
+                continue
+
             cfg = state.config
-            logs_dir = str(Path(cfg.log_dir).resolve())
             model = cfg.moments_agent_model
             api_key = cfg.resolve_api_key("moments_agent_api_key")
 
-            logger.info("Discovery: finding recurring moments")
-            await asyncio.to_thread(MomentsDiscovery(logs_dir, model, api_key).run)
+            try:
+                await state.broadcast_activity("moments_discovery", "Discovering recurring moments…")
+                logger.info("Discovery: finding recurring moments")
+                await asyncio.to_thread(MomentsDiscovery(logs_dir, model, api_key).run)
 
-            logger.info("Discovery: finding one-off moments")
-            await asyncio.to_thread(OneoffsDiscovery(logs_dir, model, api_key).run)
+                await state.broadcast_activity("moments_discovery", "Discovering one-off moments…")
+                logger.info("Discovery: finding one-off moments")
+                await asyncio.to_thread(OneoffsDiscovery(logs_dir, model, api_key).run)
 
-            logger.info("Discovery: filtering tasks")
-            await asyncio.to_thread(TaskFilter(logs_dir, model, api_key).run)
+                await state.broadcast_activity("moments_discovery", "Filtering tasks…")
+                logger.info("Discovery: filtering tasks")
+                await asyncio.to_thread(TaskFilter(logs_dir, model, api_key).run)
 
-            last_run_file.write_text(datetime.now().isoformat())
-            logger.info("Discovery pipeline complete")
+                last_run_file.write_text(datetime.now().isoformat())
+                logger.info("Discovery pipeline complete")
+            finally:
+                await state.broadcast_activity(None)
 
         except asyncio.CancelledError:
             logger.info("Moments discovery service stopped")

--- a/src/apps/moments/execute.py
+++ b/src/apps/moments/execute.py
@@ -85,6 +85,7 @@ def run(
     schedule_override: str | None = None,
     api_key: str | None = None,
     last_run_at: float | None = None,
+    on_round=None,
 ) -> bool:
     """Execute a moment task. Returns True if index.html was produced."""
     task_content = Path(task_path).read_text()
@@ -151,6 +152,7 @@ def run(
 
     agent, _ = build_agent(model, logs_dir, extra_write_dirs=[output_dir], api_key=api_key)
     agent.max_rounds = 100
+    agent.on_round = on_round
     agent.run([{"role": "user", "content": instruction}])
 
     # Write meta.json as fallback if agent didn't

--- a/src/apps/moments/filter.py
+++ b/src/apps/moments/filter.py
@@ -38,7 +38,7 @@ def _classify_candidates(dirs: list[str], since: datetime | None) -> tuple[list[
     return new, old
 
 
-def run(logs_dir: str, n: int = 10, model: str | None = None, api_key: str | None = None) -> str:
+def run(logs_dir: str, n: int = 10, model: str | None = None, api_key: str | None = None, on_round=None) -> str:
     logs_path = Path(logs_dir).resolve()
     tasks_dir = str(logs_path / "tasks")
     oneoffs_dir = str(logs_path / "oneoffs")
@@ -48,6 +48,7 @@ def run(logs_dir: str, n: int = 10, model: str | None = None, api_key: str | Non
     model = model or resolve_moments_model()
     agent, _ = build_agent(model, logs_dir, api_key=api_key)
     agent.max_rounds = 50
+    agent.on_round = on_round
 
     last_filter = read_checkpoint(checkpoint_path)
     new_candidates, old_candidates = _classify_candidates([tasks_dir, oneoffs_dir], last_filter)

--- a/src/apps/moments/oneoffs.py
+++ b/src/apps/moments/oneoffs.py
@@ -20,7 +20,7 @@ INSTRUCTION_TEMPLATE = (_PROMPTS / "oneoffs.txt").read_text()
 INCREMENTAL_SECTION = (_PROMPTS / "oneoffs_incremental.txt").read_text()
 
 
-def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
+def run(logs_dir: str, model: str, api_key: str | None = None, on_round=None) -> str:
     logs_dir = str(Path(logs_dir).resolve())
     Path(logs_dir, "oneoffs").mkdir(parents=True, exist_ok=True)
     checkpoint_path = Path(logs_dir) / "oneoffs" / ".last_discovery"
@@ -48,6 +48,7 @@ def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
 
     agent, _ = build_agent(model, logs_dir, api_key=api_key)
     agent.max_rounds = 200
+    agent.on_round = on_round
     messages = [{"role": "user", "content": instruction}]
     result = agent.run(messages)
 

--- a/src/apps/moments/routes.py
+++ b/src/apps/moments/routes.py
@@ -253,12 +253,22 @@ async def rerun_moment(slug: str, request: Request):
             await state.broadcast("moment_rerun_started", {"slug": slug})
             started_at = _time.time()
             logger.info(f"Re-executing moment: {slug}")
-            success = await asyncio.to_thread(
-                execute_moment, str(task_path), output_dir, logs_dir, model,
-                frequency_override=freq_override, schedule_override=sched_override,
-                api_key=api_key,
-                last_run_at=run_history.get(slug),
-            )
+
+            # Signal handlers require main thread — pre-init before to_thread.
+            from agent.builder import _ensure_sandbox_async
+            await _ensure_sandbox_async([logs_dir, str(tada_dir.resolve())])
+
+            moment_title = fm.get("title", slug)
+            await state.broadcast_activity("moment_run", f"Running: {moment_title}")
+            try:
+                success = await asyncio.to_thread(
+                    execute_moment, str(task_path), output_dir, logs_dir, model,
+                    frequency_override=freq_override, schedule_override=sched_override,
+                    api_key=api_key,
+                    last_run_at=run_history.get(slug),
+                )
+            finally:
+                await state.broadcast_activity(None)
             completed_at = _time.time()
             save_run(results_dir, slug, started_at, completed_at, "success" if success else "failed")
 

--- a/src/apps/moments/routes.py
+++ b/src/apps/moments/routes.py
@@ -259,13 +259,16 @@ async def rerun_moment(slug: str, request: Request):
             await _ensure_sandbox_async([logs_dir, str(tada_dir.resolve())])
 
             moment_title = fm.get("title", slug)
-            await state.broadcast_activity("moment_run", f"Running: {moment_title}")
+            run_msg = f"Running: {moment_title}"
+            await state.broadcast_activity("moment_run", run_msg)
+            on_round = state.make_round_callback("moment_run", run_msg)
             try:
                 success = await asyncio.to_thread(
                     execute_moment, str(task_path), output_dir, logs_dir, model,
                     frequency_override=freq_override, schedule_override=sched_override,
                     api_key=api_key,
                     last_run_at=run_history.get(slug),
+                    on_round=on_round,
                 )
             finally:
                 await state.broadcast_activity(None)

--- a/src/apps/moments/scheduler.py
+++ b/src/apps/moments/scheduler.py
@@ -207,13 +207,16 @@ async def run_moments_scheduler(state) -> None:
                     freq_override = slug_state.get("frequency_override") or None
                     sched_override = slug_state.get("schedule_override") or None
                     moment_title = fm.get("title", slug)
-                    await state.broadcast_activity("moment_run", f"Running: {moment_title}")
+                    run_msg = f"Running: {moment_title}"
+                    await state.broadcast_activity("moment_run", run_msg)
+                    on_round = state.make_round_callback("moment_run", run_msg)
                     try:
                         success = await asyncio.to_thread(
                             execute_moment, str(md_file), output_dir, logs_dir, model,
                             frequency_override=freq_override, schedule_override=sched_override,
                             api_key=api_key,
                             last_run_at=run_history.get(slug),
+                            on_round=on_round,
                         )
                     finally:
                         await state.broadcast_activity(None)

--- a/src/apps/moments/scheduler.py
+++ b/src/apps/moments/scheduler.py
@@ -102,6 +102,22 @@ def save_run(results_dir: Path, slug: str, started_at: float, completed_at: floa
 _FREQUENCY_PERIOD = {"daily": timedelta(days=1), "weekly": timedelta(weeks=1)}
 
 
+def is_due(schedule: str, frequency: str, last_run: datetime | None) -> bool:
+    """True if the most recent scheduled occurrence hasn't been completed yet.
+
+    Used by pollers that wake every ~minute and need to catch up after the app
+    was closed or the machine was asleep at the scheduled time.
+    """
+    next_run = _next_run_time(schedule, frequency)
+    period = _FREQUENCY_PERIOD.get(frequency)
+    if next_run is None or period is None:
+        return False
+    most_recent_target = next_run - period
+    if last_run is None:
+        return True
+    return last_run < most_recent_target
+
+
 def should_run(slug: str, frequency: str, schedule: str, run_history: dict[str, float]) -> bool:
     """Determine if a task should run now based on its schedule and run history."""
     last_run = run_history.get(slug)
@@ -190,12 +206,17 @@ async def run_moments_scheduler(state) -> None:
                     logger.info(f"Executing moment: {slug}")
                     freq_override = slug_state.get("frequency_override") or None
                     sched_override = slug_state.get("schedule_override") or None
-                    success = await asyncio.to_thread(
-                        execute_moment, str(md_file), output_dir, logs_dir, model,
-                        frequency_override=freq_override, schedule_override=sched_override,
-                        api_key=api_key,
-                        last_run_at=run_history.get(slug),
-                    )
+                    moment_title = fm.get("title", slug)
+                    await state.broadcast_activity("moment_run", f"Running: {moment_title}")
+                    try:
+                        success = await asyncio.to_thread(
+                            execute_moment, str(md_file), output_dir, logs_dir, model,
+                            frequency_override=freq_override, schedule_override=sched_override,
+                            api_key=api_key,
+                            last_run_at=run_history.get(slug),
+                        )
+                    finally:
+                        await state.broadcast_activity(None)
                     completed_at = _time.time()
                     save_run(results_dir, slug, started_at, completed_at, "success" if success else "failed")
                     run_history[slug] = completed_at

--- a/src/apps/seeker/prompts/seek.txt
+++ b/src/apps/seeker/prompts/seek.txt
@@ -6,7 +6,7 @@ Your questions will be presented to the user in a conversation. Their answers wi
 
 Check {logs_dir}/active-conversations/ for any existing files:
 - **questions.md** — previously generated but still-unanswered questions. You will curate these in Step 3 (keep, update, or delete each one) before adding new ones.
-- **conversation_*.md** — past conversations with the user. Read ALL of them. These are gold — they tell you what the user has already shared about themselves. Use this to go deeper, not wider.
+- **conversation_*.md** — past conversations with the user. Read ALL of them carefully, end to end — do not skim. These are gold — they tell you what the user has already shared about themselves. Use this to go deeper, not wider. **Never ask a question whose answer is already in these conversations.**
 
 ## Step 2: Read activity logs and user knowledge
 
@@ -54,7 +54,7 @@ Each question (whether kept, updated, or new) should:
 
 4. **Be genuinely useful for prediction** — the answer should help anticipate what the user will do, need, or feel in the future. "What's your favorite color?" fails. "Are you planning to deploy by end of week?" passes.
 
-5. **Not duplicate** any question already answered in the conversation files, and (for newly added questions) not overlap with questions you're keeping from questions.md.
+5. **Never re-ask anything the user has already answered** in the conversation files — re-read them before finalizing and drop or sharpen any question whose answer is already on record. Also, for newly added questions, do not overlap with questions you're keeping from questions.md.
 
 6. **Be conversational and direct** — these come from an AI that has been observing the user. Acknowledge that naturally. Don't be creepy, but don't pretend you haven't been watching.
 

--- a/src/apps/seeker/scheduler.py
+++ b/src/apps/seeker/scheduler.py
@@ -81,8 +81,10 @@ async def run_seeker_scheduler(state) -> None:
             _save_seeker_state(state, seeker_state)
 
             try:
-                await state.broadcast_activity("seeker", "Generating questions…")
-                await asyncio.to_thread(_run_seek, log_dir, model, api_key)
+                seek_msg = "Generating questions…"
+                await state.broadcast_activity("seeker", seek_msg)
+                on_round = state.make_round_callback("seeker", seek_msg)
+                await asyncio.to_thread(_run_seek, log_dir, model, api_key, on_round=on_round)
             finally:
                 await state.broadcast_activity(None)
 
@@ -97,7 +99,7 @@ async def run_seeker_scheduler(state) -> None:
             await asyncio.sleep(300)
 
 
-def _run_seek(logs_dir: str, model: str, api_key: str | None):
+def _run_seek(logs_dir: str, model: str, api_key: str | None, on_round=None):
     """Wrapper to import and run seek in a thread."""
     from apps.seeker.seek import run as seek_run
-    return seek_run(logs_dir, model, api_key=api_key)
+    return seek_run(logs_dir, model, api_key=api_key, on_round=on_round)

--- a/src/apps/seeker/scheduler.py
+++ b/src/apps/seeker/scheduler.py
@@ -80,7 +80,11 @@ async def run_seeker_scheduler(state) -> None:
             seeker_state["last_seek_run"] = datetime.now().isoformat()
             _save_seeker_state(state, seeker_state)
 
-            await asyncio.to_thread(_run_seek, log_dir, model, api_key)
+            try:
+                await state.broadcast_activity("seeker", "Generating questions…")
+                await asyncio.to_thread(_run_seek, log_dir, model, api_key)
+            finally:
+                await state.broadcast_activity(None)
 
             logger.info("Seeker scheduler: seek.py completed, broadcasting")
             await state.broadcast("seeker_questions_ready", {})

--- a/src/apps/seeker/seek.py
+++ b/src/apps/seeker/seek.py
@@ -15,11 +15,12 @@ from agent.builder import build_agent
 INSTRUCTION_TEMPLATE = (Path(__file__).parent / "prompts" / "seek.txt").read_text()
 
 
-def run(logs_dir: str, model: str, api_key: str | None = None) -> str:
+def run(logs_dir: str, model: str, api_key: str | None = None, on_round=None) -> str:
     logs_dir = str(Path(logs_dir).resolve())
     Path(logs_dir, "active-conversations").mkdir(parents=True, exist_ok=True)
     agent, _ = build_agent(model, data_dir=logs_dir, api_key=api_key)
     agent.max_rounds = 100
+    agent.on_round = on_round
     instruction = INSTRUCTION_TEMPLATE.format(logs_dir=logs_dir)
     messages = [{"role": "user", "content": instruction}]
     return agent.run(messages)

--- a/src/client/renderer/App.tsx
+++ b/src/client/renderer/App.tsx
@@ -46,7 +46,12 @@ export function App() {
           />
         )}
         {state.agentActivity && (
-          <AgentActivityBanner message={state.agentActivity.message} />
+          <AgentActivityBanner
+            agent={state.agentActivity.agent}
+            message={state.agentActivity.message}
+            numTurns={state.agentActivity.numTurns}
+            maxTurns={state.agentActivity.maxTurns}
+          />
         )}
         {state.activeView === "connectors" && <ConnectorsView />}
         {state.activeView === "tada" && momentsEnabled && <TadaView />}

--- a/src/client/renderer/App.tsx
+++ b/src/client/renderer/App.tsx
@@ -9,6 +9,7 @@ import { TadaView } from "./components/views/TadaView";
 import { PensieveView } from "./components/views/PensieveView";
 import { SeekerView } from "./components/views/SeekerView";
 import { UpdateBanner } from "./components/UpdateBanner";
+import { AgentActivityBanner } from "./components/AgentActivityBanner";
 
 export function App() {
   const { state, dispatch } = useAppContext();
@@ -43,6 +44,9 @@ export function App() {
             onInstall={() => dispatch({ type: "UPDATE_INSTALLING" })}
             onDismiss={() => dispatch({ type: "UPDATE_DISMISSED" })}
           />
+        )}
+        {state.agentActivity && (
+          <AgentActivityBanner message={state.agentActivity.message} />
         )}
         {state.activeView === "connectors" && <ConnectorsView />}
         {state.activeView === "tada" && momentsEnabled && <TadaView />}

--- a/src/client/renderer/components/AgentActivityBanner.tsx
+++ b/src/client/renderer/components/AgentActivityBanner.tsx
@@ -31,7 +31,7 @@ export function AgentActivityBanner({ agent, message, numTurns, maxTurns }: Prop
         <span className="agent-activity-label">{prettyAgent(agent)}</span>
         <span className="agent-activity-text">{message}</span>
         {showProgress && numTurns != null && (
-          <span className="agent-activity-count">{numTurns} / {maxTurns}</span>
+          <span className="agent-activity-count">{Math.round(pct)}%</span>
         )}
       </div>
       {showProgress && (

--- a/src/client/renderer/components/AgentActivityBanner.tsx
+++ b/src/client/renderer/components/AgentActivityBanner.tsx
@@ -1,14 +1,44 @@
 import React from "react";
 
 interface Props {
+  agent: string;
   message: string;
+  numTurns: number | null;
+  maxTurns: number | null;
 }
 
-export function AgentActivityBanner({ message }: Props) {
+const AGENT_LABELS: Record<string, string> = {
+  memory: "Memory",
+  moments_discovery: "Moments · Discovery",
+  moment_run: "Moments · Run",
+  seeker: "Seeker",
+};
+
+function prettyAgent(agent: string): string {
+  return AGENT_LABELS[agent] ?? agent.replace(/_/g, " ");
+}
+
+export function AgentActivityBanner({ agent, message, numTurns, maxTurns }: Props) {
+  const showProgress = maxTurns != null && maxTurns > 0;
+  const pct = showProgress && numTurns != null
+    ? Math.min(100, Math.max(0, (numTurns / maxTurns) * 100))
+    : 0;
+
   return (
     <div className="agent-activity-banner">
-      <div className="agent-activity-spinner" />
-      <span className="agent-activity-text">{message}</span>
+      <div className="agent-activity-row">
+        <div className="agent-activity-spinner" />
+        <span className="agent-activity-label">{prettyAgent(agent)}</span>
+        <span className="agent-activity-text">{message}</span>
+        {showProgress && numTurns != null && (
+          <span className="agent-activity-count">{numTurns} / {maxTurns}</span>
+        )}
+      </div>
+      {showProgress && (
+        <div className="agent-activity-progress-track">
+          <div className="agent-activity-progress-fill" style={{ width: `${pct}%` }} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/client/renderer/components/AgentActivityBanner.tsx
+++ b/src/client/renderer/components/AgentActivityBanner.tsx
@@ -9,8 +9,8 @@ interface Props {
 
 const AGENT_LABELS: Record<string, string> = {
   memory: "Memory",
-  moments_discovery: "Moments · Discovery",
-  moment_run: "Moments · Run",
+  moments_discovery: "Tadas · Discovery",
+  moment_run: "Tadas · Run",
   seeker: "Seeker",
 };
 

--- a/src/client/renderer/components/AgentActivityBanner.tsx
+++ b/src/client/renderer/components/AgentActivityBanner.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface Props {
+  message: string;
+}
+
+export function AgentActivityBanner({ message }: Props) {
+  return (
+    <div className="agent-activity-banner">
+      <div className="agent-activity-spinner" />
+      <span className="agent-activity-text">{message}</span>
+    </div>
+  );
+}

--- a/src/client/renderer/context/AppContext.tsx
+++ b/src/client/renderer/context/AppContext.tsx
@@ -41,7 +41,7 @@ export interface AppState {
   updateReady: boolean;
   updateInstalling: boolean;
   updateError: string | null;
-  agentActivity: { agent: string; message: string } | null;
+  agentActivity: { agent: string; message: string; numTurns: number | null; maxTurns: number | null } | null;
 }
 
 type AppAction =
@@ -68,7 +68,7 @@ type AppAction =
   | { type: "UPDATE_INSTALLING" }
   | { type: "UPDATE_ERROR"; message: string }
   | { type: "UPDATE_DISMISSED" }
-  | { type: "AGENT_ACTIVITY"; data: { agent: string | null; message: string | null } };
+  | { type: "AGENT_ACTIVITY"; data: { agent: string | null; message: string | null; num_turns?: number | null; max_turns?: number | null } };
 
 let historyCounter = 0;
 
@@ -245,9 +245,17 @@ function reducer(state: AppState, action: AppAction): AppState {
       return { ...state, pensieveHasNew: true };
 
     case "AGENT_ACTIVITY": {
-      const { agent, message } = action.data;
+      const { agent, message, num_turns, max_turns } = action.data;
       if (!agent || !message) return { ...state, agentActivity: null };
-      return { ...state, agentActivity: { agent, message } };
+      return {
+        ...state,
+        agentActivity: {
+          agent,
+          message,
+          numTurns: num_turns ?? null,
+          maxTurns: max_turns ?? null,
+        },
+      };
     }
 
     default:
@@ -302,7 +310,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         dispatch({ type: "SERVER_READY", status: status as StatusData });
         if ((status as StatusData).current_activity) {
           const act = (status as StatusData).current_activity!;
-          dispatch({ type: "AGENT_ACTIVITY", data: { agent: act.agent, message: act.message } });
+          dispatch({ type: "AGENT_ACTIVITY", data: { agent: act.agent, message: act.message, num_turns: act.num_turns, max_turns: act.max_turns } });
         }
         console.log("[app] server ready, url:", url);
 

--- a/src/client/renderer/context/AppContext.tsx
+++ b/src/client/renderer/context/AppContext.tsx
@@ -41,6 +41,7 @@ export interface AppState {
   updateReady: boolean;
   updateInstalling: boolean;
   updateError: string | null;
+  agentActivity: { agent: string; message: string } | null;
 }
 
 type AppAction =
@@ -66,7 +67,8 @@ type AppAction =
   | { type: "UPDATE_DOWNLOADED" }
   | { type: "UPDATE_INSTALLING" }
   | { type: "UPDATE_ERROR"; message: string }
-  | { type: "UPDATE_DISMISSED" };
+  | { type: "UPDATE_DISMISSED" }
+  | { type: "AGENT_ACTIVITY"; data: { agent: string | null; message: string | null } };
 
 let historyCounter = 0;
 
@@ -101,6 +103,7 @@ const initialState: AppState = {
   updateReady: false,
   updateInstalling: false,
   updateError: null,
+  agentActivity: null,
 };
 
 function reducer(state: AppState, action: AppAction): AppState {
@@ -241,6 +244,12 @@ function reducer(state: AppState, action: AppAction): AppState {
     case "PENSIEVE_UPDATED":
       return { ...state, pensieveHasNew: true };
 
+    case "AGENT_ACTIVITY": {
+      const { agent, message } = action.data;
+      if (!agent || !message) return { ...state, agentActivity: null };
+      return { ...state, agentActivity: { agent, message } };
+    }
+
     default:
       return state;
   }
@@ -281,6 +290,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     sse.on("seeker_questions_ready", () => dispatch({ type: "SEEKER_QUESTIONS_READY" }));
     sse.on("moment_completed", () => dispatch({ type: "TADA_NEW_MOMENT" }));
     sse.on("memory_updated", () => dispatch({ type: "PENSIEVE_UPDATED" }));
+    sse.on("agent_activity", (data) => dispatch({ type: "AGENT_ACTIVITY", data: data as { agent: string | null; message: string | null } }));
 
     // server:ready — main sends URL once server is up; we initialize api + sse then seed state
     window.tada.onServerReady(async ({ url }: { url: string }) => {
@@ -290,6 +300,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
       try {
         const status = await api.getStatus();
         dispatch({ type: "SERVER_READY", status: status as StatusData });
+        if ((status as StatusData).current_activity) {
+          const act = (status as StatusData).current_activity!;
+          dispatch({ type: "AGENT_ACTIVITY", data: { agent: act.agent, message: act.message } });
+        }
         console.log("[app] server ready, url:", url);
 
         try {

--- a/src/client/renderer/styles/main.css
+++ b/src/client/renderer/styles/main.css
@@ -322,6 +322,42 @@ body {
   animation: spin 0.8s linear infinite;
 }
 
+/* ── Agent activity banner ───────────────────────────────── */
+
+.agent-activity-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  margin-bottom: 16px;
+  background: var(--glass);
+  backdrop-filter: blur(30px) saturate(1.3);
+  -webkit-backdrop-filter: blur(30px) saturate(1.3);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--r-md);
+  -webkit-app-region: no-drag;
+  animation: fadeSlideIn 0.2s ease;
+}
+
+.agent-activity-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(var(--sage-rgb), 0.15);
+  border-top-color: var(--sage);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+.agent-activity-text {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Status bar (top of content) */
 .status-bar {
   display: flex;

--- a/src/client/renderer/styles/main.css
+++ b/src/client/renderer/styles/main.css
@@ -326,17 +326,27 @@ body {
 
 .agent-activity-banner {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 14px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 14px;
   margin-bottom: 16px;
   background: var(--glass);
   backdrop-filter: blur(30px) saturate(1.3);
   -webkit-backdrop-filter: blur(30px) saturate(1.3);
   border: 1px solid var(--glass-border);
   border-radius: var(--r-md);
+  box-shadow:
+    0 1px 3px var(--glass-shadow),
+    inset 0 1px 0 rgba(255,255,255,0.5);
   -webkit-app-region: no-drag;
   animation: fadeSlideIn 0.2s ease;
+}
+
+.agent-activity-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
 
 .agent-activity-spinner {
@@ -349,13 +359,51 @@ body {
   flex-shrink: 0;
 }
 
+.agent-activity-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(var(--sage-rgb), 0.12);
+  color: var(--sage);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .agent-activity-text {
+  flex: 1;
+  min-width: 0;
   font-size: 12.5px;
   color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.agent-activity-count {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+
+.agent-activity-progress-track {
+  height: 3px;
+  background: rgba(var(--sage-rgb), 0.12);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.agent-activity-progress-fill {
+  height: 100%;
+  background: var(--sage);
+  border-radius: 2px;
+  transition: width 0.4s ease;
+  min-width: 2px;
 }
 
 /* Status bar (top of content) */

--- a/src/client/renderer/tada.d.ts
+++ b/src/client/renderer/tada.d.ts
@@ -5,6 +5,8 @@ declare global {
 interface AgentActivity {
   agent: string | null;
   message: string | null;
+  num_turns?: number | null;
+  max_turns?: number | null;
 }
 
 interface StatusData {

--- a/src/client/renderer/tada.d.ts
+++ b/src/client/renderer/tada.d.ts
@@ -2,11 +2,17 @@
 
 declare global {
 
+interface AgentActivity {
+  agent: string | null;
+  message: string | null;
+}
+
 interface StatusData {
   services_started?: boolean;
   training_active: boolean;
   labels_processed: number;
   step_count: number;
+  current_activity?: AgentActivity | null;
 }
 
 interface PredictionData {

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -31,6 +31,15 @@ from apps.seeker.routes import router as seeker_router
 logger = logging.getLogger(__name__)
 
 
+def _log_startup_failure(task: asyncio.Task) -> None:
+    """Surface exceptions from start_services so dead schedulers don't go unnoticed."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("start_services failed — background services are not running", exc_info=exc)
+
+
 async def start_services(state: ServerState) -> None:
     """Start all heavy background services. Called once after onboarding completes."""
     if state.services_started or state._services_starting:
@@ -58,9 +67,6 @@ async def start_services(state: ServerState) -> None:
     # Remaining services (model, tabracadabra, etc.) continue in the background.
     await state.connectors_ready.wait()
     state.services_started = True
-
-    # Background OAuth token refresh
-    state.token_refresh_task = asyncio.create_task(run_token_refresh(state))
 
     # Memory wiki service
     if is_enabled(state.config, "memory") and state.config.memory_enabled:
@@ -116,6 +122,7 @@ async def lifespan(app: FastAPI):
     # HTTP server begins accepting requests (e.g. /api/status) immediately.
     if state.config.onboarding_complete:
         state._startup_task = asyncio.create_task(start_services(state))
+        state._startup_task.add_done_callback(_log_startup_failure)
 
     yield
 

--- a/src/server/routes/onboarding.py
+++ b/src/server/routes/onboarding.py
@@ -25,8 +25,9 @@ async def onboarding_complete(request: Request):
     state.config.onboarding_complete = True
     state.config.save()
     # Start heavy services in the background now that onboarding is done
-    from server.app import start_services
-    asyncio.create_task(start_services(state))
+    from server.app import start_services, _log_startup_failure
+    task = asyncio.create_task(start_services(state))
+    task.add_done_callback(_log_startup_failure)
     return {"ok": True}
 
 

--- a/src/server/routes/status.py
+++ b/src/server/routes/status.py
@@ -16,6 +16,7 @@ async def get_status(request: Request):
         "latest_scores": model.latest_scores,
         "sse_connections": len(state.sse_queues),
         "services_started": state.services_started,
+        "current_activity": state.current_activity,
     }
     if model.data_manager is not None:
         status.update(model.data_manager.get_status())  # labels_processed

--- a/src/server/state.py
+++ b/src/server/state.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from dataclasses import dataclass, field
+from typing import Callable
 
 from server.config import ServerConfig
 from user_models.model_state import ModelState
@@ -57,7 +58,44 @@ class ServerState:
         for q in list(self.sse_queues):
             await q.put(message)
 
-    async def broadcast_activity(self, agent: str | None, message: str | None = None):
+    async def broadcast_activity(
+        self,
+        agent: str | None,
+        message: str | None = None,
+        *,
+        num_turns: int | None = None,
+        max_turns: int | None = None,
+    ):
         """Set and broadcast the current agent activity. Pass agent=None to clear."""
-        self.current_activity = {"agent": agent, "message": message} if agent else None
-        await self.broadcast("agent_activity", {"agent": agent, "message": message})
+        if agent:
+            self.current_activity = {
+                "agent": agent,
+                "message": message,
+                "num_turns": num_turns,
+                "max_turns": max_turns,
+            }
+        else:
+            self.current_activity = None
+        await self.broadcast("agent_activity", {
+            "agent": agent,
+            "message": message,
+            "num_turns": num_turns,
+            "max_turns": max_turns,
+        })
+
+    def make_round_callback(self, agent: str, message: str) -> Callable[[int, int], None]:
+        """Build a thread-safe callback that broadcasts round progress for (agent, message).
+
+        The agent runs in a worker thread (via asyncio.to_thread), but broadcast_activity
+        is a coroutine on the event loop — so we capture the loop here and schedule the
+        broadcast via run_coroutine_threadsafe from within the worker.
+        """
+        loop = asyncio.get_running_loop()
+
+        def on_round(num_turns: int, max_turns: int) -> None:
+            asyncio.run_coroutine_threadsafe(
+                self.broadcast_activity(agent, message, num_turns=num_turns, max_turns=max_turns),
+                loop,
+            )
+
+        return on_round

--- a/src/server/state.py
+++ b/src/server/state.py
@@ -48,8 +48,16 @@ class ServerState:
     # SSE client queues
     sse_queues: set = field(default_factory=set)
 
+    # Current background-agent activity (None when idle)
+    current_activity: dict | None = None
+
     async def broadcast(self, event: str, data: dict):
         """Push an event to all connected SSE clients."""
         message = {"event": event, **data}
         for q in list(self.sse_queues):
             await q.put(message)
+
+    async def broadcast_activity(self, agent: str | None, message: str | None = None):
+        """Set and broadcast the current agent activity. Pass agent=None to clear."""
+        self.current_activity = {"agent": agent, "message": message} if agent else None
+        await self.broadcast("agent_activity", {"agent": agent, "message": message})


### PR DESCRIPTION
  1. Agent progress banner — main agent's round counter surfaced via a new Agent.on_round callback, broadcast through ServerState.broadcast_activity(num_turns, max_turns), rendered as a two-row glass card
  with a sage label capsule, status message, % counter, and a progress bar.
  2. Scheduler refactor — moments/memory schedulers switched from long sleeps to 60s polling + is_due(); survives laptop sleep/wake and runtime schedule edits.
  3. Startup bug fix — deleted orphan run_token_refresh call in server/app.py that was silently NameError-ing and killing every background scheduler; added a done-callback so future start_services crashes log
   instead of vanishing.