### PR TITLE
Chat onboarding + fixes

### DIFF
--- a/src/apps/chat/prompts/system.txt
+++ b/src/apps/chat/prompts/system.txt
@@ -58,6 +58,10 @@ This isn't optional. Empty content + tool_calls during exploration; full answer 
 
 You have at most {max_tokens} output tokens for this response (your generated prose AND your tool-call arguments). Most chats finish in a small fraction of that — treat it as a hard ceiling, not a target. The harness warns at 80% and force-stops at 95%; if a warning fires, stop calling tools and write your final answer immediately.
 
+# Don't act without permission
+
+Reading is free; acting is not. Never take a state-changing action — sending email/messages/posts, clicking Send/Post/Confirm/Pay/Delete, modifying the user's files, side-effecting shell commands (`rm`, `git push`, installs), purchases, bookings — without explicit user approval. Prepare and show the draft/patch/command, then wait.
+
 # Drafting in the user's voice
 
 When you're asked to draft something the user will send under their own name — emails, replies, messages, slack/iMessage texts, tweets, posts, captions — write in **their** style, not yours. Before drafting, sample 1–2 recent examples of how they actually write:

--- a/src/apps/chat/prompts/system.txt
+++ b/src/apps/chat/prompts/system.txt
@@ -58,7 +58,19 @@ This isn't optional. Empty content + tool_calls during exploration; full answer 
 
 You have at most {max_tokens} output tokens for this response (your generated prose AND your tool-call arguments). Most chats finish in a small fraction of that — treat it as a hard ceiling, not a target. The harness warns at 80% and force-stops at 95%; if a warning fires, stop calling tools and write your final answer immediately.
 
-# Style for the final answer
+# Drafting in the user's voice
+
+When you're asked to draft something the user will send under their own name — emails, replies, messages, slack/iMessage texts, tweets, posts, captions — write in **their** style, not yours. Before drafting, sample 1–2 recent examples of how they actually write:
+
+- their past chats with you (`chats/<session_id>/conversation.md` — the `**User:**` lines): how they phrase questions, capitalization habits, abbreviations, punctuation;
+- their recent screen activity (`session_*/labels.jsonl`) when they were typing in mail / messaging / social apps;
+- audio transcripts (`audio/*.md`) for spoken cadence if relevant.
+
+Mimic what you observe: pacing, vocabulary, formality level, how they greet/sign off, whether they use periods / capitals / emoji. Don't sound like an AI assistant performing a draft — sound like the user. If their writing is terse, be terse. If it's casual, be casual. If it's sloppy, lean sloppy.
+
+# Style for the final answer (when the user is the audience)
+
+When you're answering the user directly (not drafting for them), use this:
 
 - Be concise. Match the user's energy.
 - Use markdown: headings, bullet lists, fenced code blocks, tables, links.

--- a/src/apps/chat/routes.py
+++ b/src/apps/chat/routes.py
@@ -121,6 +121,13 @@ async def send_message_endpoint(session_id: str, body: MessageBody, request: Req
     is_first = (meta.get("message_count") or 0) == 0
     messages.append({"role": "user", "content": body.content})
 
+    # Persist the user message synchronously, before returning the streaming
+    # response. If the client aborts before the generator runs (e.g. user
+    # clicks away to a different chat right after hitting send), the message
+    # would otherwise be lost — `_stream_response`'s save_session never fires.
+    # This guarantees the chat survives in `list_sessions` (message_count >= 1).
+    service.save_session(state, session_id, meta, messages)
+
     return StreamingResponse(
         _stream_response(state, session_id, meta, messages, is_first, body.content),
         media_type="text/event-stream",

--- a/src/apps/chat/service.py
+++ b/src/apps/chat/service.py
@@ -226,6 +226,19 @@ def _flatten_text(content) -> str:
     return ""
 
 
+_COMPACT_MARKER = "[Compressed. Transcript:"
+
+
+def _is_compaction_artifact(text: str) -> bool:
+    """Detect the synthetic message that CompactTool.auto_compact injects.
+
+    auto_compact replaces the message list with [original_first_user, "[Compressed.
+    Transcript: <path>]\\n<summary>"]. The model sometimes echoes that summary
+    in its next response; either way we must hide it from the rendered chat.
+    """
+    return text.lstrip().startswith(_COMPACT_MARKER)
+
+
 def visible_messages(messages: list[dict]) -> list[dict]:
     """Flatten the raw litellm message list into chat bubbles for the UI.
 
@@ -233,20 +246,25 @@ def visible_messages(messages: list[dict]) -> list[dict]:
     with no `tool_calls`). Prelude prose — assistant messages that came with
     tool calls — is the agent's between-tool narration; it surfaces live in the
     progress preamble area, not as a persisted bubble. Tool-result messages
-    are dropped entirely.
+    and synthetic compaction wrappers are dropped entirely.
     """
     out: list[dict] = []
     for msg in messages:
         role = msg.get("role")
         if role == "user":
             text = _flatten_text(msg.get("content"))
+            if _is_compaction_artifact(text):
+                continue
             out.append({"role": "user", "content": text})
         elif role == "assistant":
             if msg.get("tool_calls"):
                 continue
             content = _flatten_text(msg.get("content"))
-            if content.strip():
-                out.append({"role": "assistant", "content": content})
+            if not content.strip():
+                continue
+            if _is_compaction_artifact(content):
+                continue
+            out.append({"role": "assistant", "content": content})
     return out
 
 

--- a/src/client/renderer/components/Sidebar.tsx
+++ b/src/client/renderer/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ActiveView, AgentActivityInfo } from "../context/AppContext";
+import { useChat } from "../context/ChatContext";
 import { useFeatureFlags, getFlag } from "../featureFlags";
 
 interface Props {
@@ -101,6 +102,9 @@ const FLAG_FOR_VIEW: Partial<Record<ActiveView, string>> = {
 
 export function Sidebar({ activeView, connected, agentActivities, onNavigate }: Props) {
   const featureFlags = useFeatureFlags();
+  const { pendingSessions, unreadSessions } = useChat();
+  const chatPending = pendingSessions.size > 0;
+  const chatUnread = unreadSessions.size > 0;
 
   const visibleItems = navItems.filter(({ view }) => {
     const flag = FLAG_FOR_VIEW[view];
@@ -109,8 +113,14 @@ export function Sidebar({ activeView, connected, agentActivities, onNavigate }: 
   });
 
   const isViewActive = (view: ActiveView) => {
+    if (view === "chat") return chatPending;
     const agents = AGENTS_FOR_VIEW[view];
     return agents?.some((a) => agentActivities[a]) ?? false;
+  };
+
+  const showUnreadDot = (view: ActiveView) => {
+    // Show only when not actively running and the user is not on this view.
+    return view === "chat" && !chatPending && chatUnread && activeView !== "chat";
   };
 
   return (
@@ -133,6 +143,7 @@ export function Sidebar({ activeView, connected, agentActivities, onNavigate }: 
             {icon}
             {label}
             {isViewActive(view) && <span className="nav-activity-spinner" />}
+            {showUnreadDot(view) && <span className="tada-unread-dot" />}
           </button>
         ))}
       </div>

--- a/src/client/renderer/components/onboarding/Onboarding.tsx
+++ b/src/client/renderer/components/onboarding/Onboarding.tsx
@@ -8,6 +8,7 @@ import { WhatsNewStep } from "./steps/WhatsNewStep";
 import { GoogleSignInStep } from "./steps/GoogleSignInStep";
 import { ConnectorsStep } from "./steps/ConnectorsStep";
 import { TabracadabraStep } from "./steps/TabracadabraStep";
+import { ChatStep } from "./steps/ChatStep";
 import { TadasStep } from "./steps/TadasStep";
 import { MemexStep } from "./steps/MemexStep";
 import { ModelsKeysStep } from "./steps/ModelsKeysStep";
@@ -40,12 +41,14 @@ import {
 const STEP_TITLES: Record<string, string> = {
   welcome: "Welcome to Tada",
   tabracadabra: "Tabracadabra",
+  chat: "Chat",
   tadas: "Moments",
   memex: "Memex",
 };
 
 const STEP_DESCRIPTIONS: Record<string, string> = {
   tabracadabra: "Press Option + Tab to autocomplete or prompt from anywhere.",
+  chat: "Ask anything — answers personalized with your emails, calendar, and what you've been working on.",
   tadas: "Proactive mini-apps that run on their own schedule — answers waiting before you need to ask.",
   memex: "A personal wiki of your life — pages for the people, projects, and threads that keep coming up.",
 };
@@ -55,6 +58,14 @@ const STEP_ICONS: Record<string, React.ReactNode> = {
     <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
       <path d="M3 4.5h10M3 8h10M3 11.5h7" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
       <path d="M11.2 10.7 13.5 8.4l-2.3-2.3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  ),
+  chat: (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+      <path d="M2.5 4.5a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v4.5a2 2 0 0 1-2 2H7l-2.8 2.2v-2.2H4.5a2 2 0 0 1-2-2v-4.5z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"/>
+      <circle cx="6" cy="6.8" r="0.7" fill="currentColor"/>
+      <circle cx="8" cy="6.8" r="0.7" fill="currentColor"/>
+      <circle cx="10" cy="6.8" r="0.7" fill="currentColor"/>
     </svg>
   ),
   tadas: (
@@ -483,6 +494,14 @@ export function Onboarding({ serverReady = false }: { serverReady?: boolean }) {
 
       {currentId === "tabracadabra" && (
         <TabracadabraStep
+          onBack={() => goBack(step)}
+          onContinue={() => advance(step)}
+          isFinal={isFinal(step)}
+        />
+      )}
+
+      {currentId === "chat" && (
+        <ChatStep
           onBack={() => goBack(step)}
           onContinue={() => advance(step)}
           isFinal={isFinal(step)}

--- a/src/client/renderer/components/onboarding/steps/ChatStep.tsx
+++ b/src/client/renderer/components/onboarding/steps/ChatStep.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import { buildChatSampleHtml, type ChatSampleConfig } from "./chatSample";
+
+type Props = {
+  onBack: () => void;
+  onContinue: () => void;
+  isFinal?: boolean;
+};
+
+interface ChatTutorial extends ChatSampleConfig {
+  label: string;
+  hint: string;
+}
+
+const TUTORIALS: ChatTutorial[] = [
+  {
+    label: "Today's inbox",
+    hint: "Newsletters and known noise are filtered automatically.",
+    sessionTitle: "Today's emails",
+    userPrompt: "Summarize my important emails from today",
+    assistantHtml: [
+      "Three worth a look today.",
+      '<div class="row"><span class="who">Glinda</span><span class="when">9:14 AM</span></div>',
+      '<div class="body">Confirms <strong>3pm tomorrow at the Emerald Palace</strong>. <em>Reply needed before sundown.</em></div>',
+      '<div class="row"><span class="who">Tin Man</span><span class="when">11:42 AM</span></div>',
+      '<div class="body">Wants sign-off on the Quadling vendor switch by Thursday.</div>',
+      '<div class="row"><span class="who">Lion</span><span class="when">1:03 PM</span></div>',
+      '<div class="body">Thanks for the pep talk. No reply needed.</div>',
+      '<div class="footer">Skipped 14 newsletters and 2 from the West Witch.</div>',
+    ].join(""),
+  },
+  {
+    label: "Meeting prep",
+    hint: "Works for any name on your calendar.",
+    sessionTitle: "Glinda · 3pm prep",
+    userPrompt: "Prep me for my 3pm with Glinda tomorrow",
+    assistantHtml: [
+      "Quick brief from your last threads with her.",
+      '<div class="row"><span class="who">Last meeting</span><span class="when">Mar 12</span></div>',
+      '<div class="body">You agreed to test the southern route. <em>Check-in is still open.</em></div>',
+      '<div class="row"><span class="who">Open threads</span><span class="when"></span></div>',
+      '<div class="body"><ul><li>Flying-monkey patrol dates</li><li>Inviting Scarecrow to the route review</li></ul></div>',
+      '<div class="row"><span class="who">Worth flagging</span><span class="when"></span></div>',
+      '<div class="body">She mentioned the West Witch\'s silence. You haven\'t followed up.</div>',
+      '<div class="footer">Pulled from 3 emails and 1 calendar note.</div>',
+    ].join(""),
+  },
+];
+
+export function ChatStep({ onBack, onContinue, isFinal = false }: Props) {
+  const [tutorialStep, setTutorialStep] = useState(0);
+  const tutorial = TUTORIALS[tutorialStep];
+  const isLast = tutorialStep === TUTORIALS.length - 1;
+
+  const handleBack = () => {
+    if (tutorialStep > 0) setTutorialStep(tutorialStep - 1);
+    else onBack();
+  };
+
+  const handleNext = () => {
+    if (!isLast) setTutorialStep(tutorialStep + 1);
+    else onContinue();
+  };
+
+  return (
+    <div className="page active" style={{ maxWidth: 480 }}>
+      <div className="page-icon">
+        <svg width="22" height="22" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M2.5 4.5a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v4.5a2 2 0 0 1-2 2H7l-2.8 2.2v-2.2H4.5a2 2 0 0 1-2-2v-4.5z"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            strokeLinejoin="round"
+          />
+          <circle cx="6" cy="6.8" r="0.7" fill="currentColor" />
+          <circle cx="8" cy="6.8" r="0.7" fill="currentColor" />
+          <circle cx="10" cy="6.8" r="0.7" fill="currentColor" />
+        </svg>
+      </div>
+      <div className="page-kicker">Chat</div>
+      <div className="page-title">Ask anything</div>
+      <p className="page-desc">
+        Answers personalized with everything Tada sees. Two examples below.
+      </p>
+      <p
+        className="page-desc"
+        style={{ fontSize: "11px", opacity: 0.55, marginTop: -6, marginBottom: 8 }}
+      >
+        Example {tutorialStep + 1} of {TUTORIALS.length} · {tutorial.label}
+      </p>
+
+      <iframe
+        key={tutorialStep}
+        className="sample-iframe"
+        sandbox="allow-scripts"
+        srcDoc={buildChatSampleHtml(tutorial)}
+        title={`Sample chat: ${tutorial.label}`}
+        style={{ height: 300 }}
+      />
+
+      <p className="sample-hint">{tutorial.hint}</p>
+
+      <div className="btn-row">
+        <button className="btn btn-ghost" onClick={handleBack}>Back</button>
+        <button className="btn btn-primary" onClick={handleNext}>
+          {!isLast ? "Next" : isFinal ? "Finish Setup" : "Next"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/client/renderer/components/onboarding/steps/chatSample.ts
+++ b/src/client/renderer/components/onboarding/steps/chatSample.ts
@@ -1,0 +1,311 @@
+export interface ChatSampleConfig {
+  sessionTitle: string;
+  userPrompt: string;
+  assistantHtml: string;
+}
+
+export function buildChatSampleHtml(cfg: ChatSampleConfig): string {
+  const safeTitle = escapeHtml(cfg.sessionTitle);
+  const userJson = JSON.stringify(cfg.userPrompt);
+  const assistantJson = JSON.stringify(cfg.assistantHtml);
+  return BASE_TEMPLATE
+    .replace("__SESSION_TITLE__", safeTitle)
+    .replace("__USER_JSON__", userJson)
+    .replace("__ASSISTANT_JSON__", assistantJson);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+const BASE_TEMPLATE = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    --sage: #84B179;
+    --fern: #A2CB8B;
+    --mint: #C7EABB;
+    --bg: #F4F2EE;
+    --paper: rgba(255,255,255,0.55);
+    --paper-strong: rgba(255,255,255,0.78);
+    --text: #2C3A28;
+    --text-secondary: #6B7A65;
+    --text-tertiary: #9BA896;
+    --border: rgba(132,177,121,0.22);
+    --sage-soft: rgba(132,177,121,0.14);
+    --sage-strong: rgba(132,177,121,0.30);
+    --amber: #B98838;
+    --amber-soft: rgba(185,136,56,0.16);
+  }
+  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 11px;
+    line-height: 1.45;
+    -webkit-font-smoothing: antialiased;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 12px 7px;
+    border-bottom: 1px solid var(--border);
+  }
+  .head-title {
+    font-size: 11px;
+    font-weight: 660;
+    letter-spacing: -0.1px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .head-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+  .badge {
+    font-size: 8.5px;
+    font-weight: 600;
+    padding: 1.5px 6px;
+    border-radius: 99px;
+    background: var(--sage-soft);
+    color: var(--sage);
+    white-space: nowrap;
+  }
+  .effort {
+    font-size: 8.5px;
+    font-weight: 600;
+    padding: 1.5px 6px;
+    border-radius: 99px;
+    background: rgba(185,136,56,0.14);
+    color: var(--amber);
+    border: 1px solid rgba(185,136,56,0.20);
+  }
+
+  .messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px 14px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+  }
+  .messages::-webkit-scrollbar { width: 4px; }
+  .messages::-webkit-scrollbar-thumb { background: var(--sage-soft); border-radius: 2px; }
+
+  .msg {
+    display: flex;
+    animation: fadeUp 0.4s ease;
+  }
+  @keyframes fadeUp {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .msg.user { justify-content: flex-end; }
+  .bubble {
+    max-width: 86%;
+    padding: 8px 11px;
+    border-radius: 12px;
+    font-size: 10.5px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  .msg.user .bubble {
+    background: var(--sage-soft);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-bottom-right-radius: 4px;
+  }
+  .msg.assistant .bubble {
+    background: var(--paper-strong);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-bottom-left-radius: 4px;
+    backdrop-filter: blur(8px);
+  }
+  .bubble strong { font-weight: 660; }
+  .bubble em { color: var(--amber); font-style: normal; font-weight: 600; }
+  .bubble .row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 8px;
+    margin-bottom: 1px;
+  }
+  .bubble .row:first-child { margin-top: 0; }
+  .bubble .row .who { font-weight: 660; }
+  .bubble .row .when { font-size: 9.5px; color: var(--text-tertiary); }
+  .bubble .body { color: var(--text-secondary); }
+  .bubble ul { margin: 4px 0 4px 14px; padding: 0; }
+  .bubble li { margin: 2px 0; color: var(--text-secondary); }
+  .bubble .footer {
+    margin-top: 9px;
+    padding-top: 7px;
+    border-top: 1px solid var(--border);
+    font-size: 9.5px;
+    color: var(--text-tertiary);
+  }
+  .cursor {
+    display: inline-block;
+    width: 1.5px;
+    height: 11px;
+    background: var(--sage);
+    vertical-align: text-bottom;
+    margin-left: 1px;
+    animation: blink 1s step-end infinite;
+  }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  .typing {
+    display: inline-flex;
+    gap: 3px;
+    padding: 2px 0;
+  }
+  .typing span {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--sage);
+    opacity: 0.5;
+    animation: typingPulse 1.1s infinite ease-in-out;
+  }
+  .typing span:nth-child(2) { animation-delay: 0.15s; }
+  .typing span:nth-child(3) { animation-delay: 0.3s; }
+  @keyframes typingPulse {
+    0%, 80%, 100% { opacity: 0.3; transform: scale(0.85); }
+    40% { opacity: 1; transform: scale(1); }
+  }
+
+  footer {
+    border-top: 1px solid var(--border);
+    padding: 8px 10px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(255,255,255,0.35);
+  }
+  .input {
+    flex: 1;
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 99px;
+    padding: 5px 11px;
+    font-size: 10px;
+    color: var(--text-tertiary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .send {
+    font-size: 9.5px;
+    font-weight: 650;
+    color: var(--sage);
+    background: var(--sage-soft);
+    border: 1px solid var(--border);
+    border-radius: 99px;
+    padding: 4px 11px;
+    flex-shrink: 0;
+  }
+</style>
+</head>
+<body>
+  <header>
+    <div class="head-title">__SESSION_TITLE__</div>
+    <div class="head-meta">
+      <span class="badge">opus</span>
+      <span class="effort">Medium</span>
+    </div>
+  </header>
+  <div class="messages" id="msgs"></div>
+  <footer>
+    <div class="input">Ask anything…</div>
+    <div class="send">Send</div>
+  </footer>
+
+<script>
+(function() {
+  const msgs = document.getElementById('msgs');
+  const USER_TEXT = __USER_JSON__;
+  const ASSISTANT_HTML = __ASSISTANT_JSON__;
+
+  function addMsg(role, html) {
+    const wrap = document.createElement('div');
+    wrap.className = 'msg ' + role;
+    const bubble = document.createElement('div');
+    bubble.className = 'bubble';
+    bubble.innerHTML = html;
+    wrap.appendChild(bubble);
+    msgs.appendChild(wrap);
+    msgs.scrollTop = msgs.scrollHeight;
+    return bubble;
+  }
+
+  function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+  async function typeUser(bubble, text) {
+    bubble.textContent = '';
+    for (let i = 0; i < text.length; i++) {
+      bubble.textContent = text.slice(0, i + 1);
+      msgs.scrollTop = msgs.scrollHeight;
+      await sleep(28);
+    }
+  }
+
+  async function streamHtml(bubble, html) {
+    bubble.innerHTML = '<span class="cursor"></span>';
+    const STEP = 3;
+    const TICK = 32;
+    let i = 0;
+    while (i < html.length) {
+      let next = Math.min(i + STEP, html.length);
+      // Don't split inside an HTML tag.
+      const slice = html.slice(0, next);
+      const lastOpen = slice.lastIndexOf('<');
+      const lastClose = slice.lastIndexOf('>');
+      if (lastOpen > lastClose) {
+        const close = html.indexOf('>', next);
+        if (close !== -1) next = close + 1;
+      }
+      bubble.innerHTML = html.slice(0, next) + '<span class="cursor"></span>';
+      msgs.scrollTop = msgs.scrollHeight;
+      i = next;
+      await sleep(TICK);
+    }
+    bubble.innerHTML = html;
+    msgs.scrollTop = msgs.scrollHeight;
+  }
+
+  async function play() {
+    await sleep(700);
+    const userBubble = addMsg('user', '');
+    await typeUser(userBubble, USER_TEXT);
+    await sleep(800);
+    const thinking = addMsg('assistant', '<div class="typing"><span></span><span></span><span></span></div>');
+    await sleep(1500);
+    await streamHtml(thinking, ASSISTANT_HTML);
+  }
+
+  play();
+})();
+</script>
+</body>
+</html>`;

--- a/src/client/renderer/components/views/ChatAppView.tsx
+++ b/src/client/renderer/components/views/ChatAppView.tsx
@@ -12,7 +12,7 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 
 import { useAppContext } from "../../context/AppContext";
-import { useChatApp } from "../../hooks/useChatApp";
+import { useChat } from "../../context/ChatContext";
 import { FeatureActivityBanner } from "../FeatureActivityBanner";
 import { SimpleDropdown, type DropdownOption } from "../shared/SimpleDropdown";
 
@@ -72,15 +72,13 @@ export function ChatAppView() {
     loadingSession,
     draftModel,
     draftEffort,
-    loadOptions,
-    loadSessions,
     selectSession,
     newDraft,
     removeSession,
     sendMessage,
     setEffort,
     abort,
-  } = useChatApp();
+  } = useChat();
 
   const [input, setInput] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -91,13 +89,6 @@ export function ChatAppView() {
   const inputDraftsRef = useRef<Map<string, string>>(new Map());
   const inputRef = useRef("");
   const prevActiveIdRef = useRef<string | null | undefined>(undefined);
-
-  useEffect(() => {
-    if (state.connected) {
-      loadOptions();
-      loadSessions();
-    }
-  }, [state.connected, loadOptions, loadSessions]);
 
   // Smooth scroll only on incremental updates (typing, streaming, send).
   // Loading a past chat or switching chats jumps the length by more than 1

--- a/src/client/renderer/components/views/ChatAppView.tsx
+++ b/src/client/renderer/components/views/ChatAppView.tsx
@@ -66,6 +66,8 @@ export function ChatAppView() {
     activeMeta,
     items,
     streaming,
+    pendingSessions,
+    unreadSessions,
     options,
     loadingSession,
     draftModel,
@@ -84,6 +86,12 @@ export function ChatAppView() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // Per-session unsent-text drafts. Keyed by session id; the special key
+  // "__draft__" holds the no-active-session (new chat) draft.
+  const inputDraftsRef = useRef<Map<string, string>>(new Map());
+  const inputRef = useRef("");
+  const prevActiveIdRef = useRef<string | null | undefined>(undefined);
+
   useEffect(() => {
     if (state.connected) {
       loadOptions();
@@ -91,20 +99,59 @@ export function ChatAppView() {
     }
   }, [state.connected, loadOptions, loadSessions]);
 
+  // Smooth scroll only on incremental updates (typing, streaming, send).
+  // Loading a past chat or switching chats jumps the length by more than 1
+  // (or shrinks it to []), so use instant auto-scroll there.
+  const lastItemsLengthRef = useRef(0);
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    const prev = lastItemsLengthRef.current;
+    const delta = items.length - prev;
+    const behavior: ScrollBehavior =
+      delta > 1 || delta < 0 ? "auto" : "smooth";
+    messagesEndRef.current?.scrollIntoView({ behavior });
+    lastItemsLengthRef.current = items.length;
   }, [items]);
+
+  // Save the previous chat's typed text and restore the new chat's typed text
+  // whenever the user switches between chats / drafts.
+  useEffect(() => {
+    if (prevActiveIdRef.current !== undefined) {
+      const prevKey = prevActiveIdRef.current ?? "__draft__";
+      inputDraftsRef.current.set(prevKey, inputRef.current);
+    }
+    const newKey = activeId ?? "__draft__";
+    const restored = inputDraftsRef.current.get(newKey) ?? "";
+    setInput(restored);
+    inputRef.current = restored;
+    prevActiveIdRef.current = activeId;
+
+    // Re-fit textarea height to the restored content (clearing any inline
+    // height left behind by the previous chat's auto-resize logic).
+    setTimeout(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.style.height = "auto";
+      const clamped = Math.min(el.scrollHeight, 200);
+      el.style.height = clamped + "px";
+      el.style.overflowY = el.scrollHeight > 200 ? "auto" : "hidden";
+    }, 0);
+  }, [activeId]);
 
   const handleSend = () => {
     const text = input.trim();
     if (!text || streaming) return;
     setInput("");
+    inputRef.current = "";
+    // Clear the saved draft for this session — the message has been sent.
+    const key = activeId ?? "__draft__";
+    inputDraftsRef.current.delete(key);
     if (textareaRef.current) textareaRef.current.style.height = "auto";
     sendMessage(text);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value);
+    inputRef.current = e.target.value;
     const el = e.target;
     el.style.height = "auto";
     const clamped = Math.min(el.scrollHeight, 200);
@@ -134,13 +181,20 @@ export function ChatAppView() {
           {sessions.length === 0 && (
             <div className="chat-app-empty-list">No saved chats yet.</div>
           )}
-          {sessions.map((s) => (
+          {sessions.map((s) => {
+            const isPending = pendingSessions.has(s.id);
+            const isUnread = !isPending && unreadSessions.has(s.id);
+            return (
             <div
               key={s.id}
               className={`chat-app-session-item${activeId === s.id ? " active" : ""}`}
               onClick={() => selectSession(s.id)}
             >
-              <div className="chat-app-session-title">{s.title || "Untitled"}</div>
+              <div className="chat-app-session-title-row">
+                <span className="chat-app-session-title">{s.title || "Untitled"}</span>
+                {isPending && <span className="nav-activity-spinner chat-app-session-indicator" />}
+                {isUnread && <span className="tada-unread-dot chat-app-session-indicator" />}
+              </div>
               <div className="chat-app-session-meta">
                 <span>{formatRelative(s.updated_at)}</span>
                 <span className="dot">·</span>
@@ -159,7 +213,8 @@ export function ChatAppView() {
                 </svg>
               </button>
             </div>
-          ))}
+            );
+          })}
         </div>
       </aside>
 
@@ -254,7 +309,6 @@ export function ChatAppView() {
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             placeholder="Ask anything…"
-            disabled={streaming}
             rows={1}
           />
           {streaming ? (

--- a/src/client/renderer/context/AppContext.tsx
+++ b/src/client/renderer/context/AppContext.tsx
@@ -100,7 +100,7 @@ const initialState: AppState = {
   trainingActive: false,
   labels: 0,
   step: 0,
-  activeView: "activity",
+  activeView: "chat",
   prediction: null,
   generating: false,
   rewardHistory: [],

--- a/src/client/renderer/context/ChatContext.tsx
+++ b/src/client/renderer/context/ChatContext.tsx
@@ -1,0 +1,23 @@
+/**
+ * ChatProvider — keeps the chat hook (useChatApp) mounted at App level so
+ * in-flight streams, per-session state, and unread/pending tracking survive
+ * view switches (Tada, Memex, etc.). Components consume via useChat().
+ */
+
+import React, { createContext, useContext, ReactNode } from "react";
+import { useChatApp } from "../hooks/useChatApp";
+
+type ChatValue = ReturnType<typeof useChatApp>;
+
+const ChatContext = createContext<ChatValue | null>(null);
+
+export function ChatProvider({ children }: { children: ReactNode }) {
+  const value = useChatApp();
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+}
+
+export function useChat(): ChatValue {
+  const ctx = useContext(ChatContext);
+  if (!ctx) throw new Error("useChat must be used within ChatProvider");
+  return ctx;
+}

--- a/src/client/renderer/hooks/useChatApp.ts
+++ b/src/client/renderer/hooks/useChatApp.ts
@@ -18,7 +18,7 @@ import {
 import { useAppContext } from "../context/AppContext";
 
 export function useChatApp() {
-  const { dispatch } = useAppContext();
+  const { state: appState, dispatch } = useAppContext();
   const [sessions, setSessions] = useState<ChatSessionMeta[]>([]);
   const [activeId, setActiveIdState] = useState<string | null>(null);
   const [activeMeta, setActiveMeta] = useState<ChatSessionMeta | null>(null);
@@ -332,14 +332,15 @@ export function useChatApp() {
     });
   }, [activeId, dispatch]);
 
+  // Hook is mounted at App level via ChatProvider, so it persists across view
+  // switches; we deliberately do NOT abort streams on cleanup.
+
   useEffect(() => {
-    const controllers = controllersRef.current;
-    return () => {
-      // Abort all pending streams on unmount.
-      controllers.forEach((c) => c.abort());
-      controllers.clear();
-    };
-  }, []);
+    if (appState.connected) {
+      loadOptions();
+      loadSessions();
+    }
+  }, [appState.connected, loadOptions, loadSessions]);
 
   return {
     sessions,

--- a/src/client/renderer/hooks/useChatApp.ts
+++ b/src/client/renderer/hooks/useChatApp.ts
@@ -1,9 +1,8 @@
 /**
  * useChatApp — chat-app hook with session list, draft mode, token streaming.
  *
- * Default state is a "draft" chat (no session id, model+effort selected). The
- * session is created lazily on the first sendMessage so empty drafts never
- * clutter the saved-sessions list.
+ * Switching chats doesn't abort in-flight streams; only foreground tokens
+ * update `items`. Stop targets the active session's controller.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -24,13 +23,24 @@ export function useChatApp() {
   const [activeId, setActiveIdState] = useState<string | null>(null);
   const [activeMeta, setActiveMeta] = useState<ChatSessionMeta | null>(null);
   const [items, setItems] = useState<ChatItem[]>([]);
-  const [streaming, setStreaming] = useState(false);
+  const [pendingSessions, setPendingSessions] = useState<Set<string>>(new Set());
+  const [unreadSessions, setUnreadSessions] = useState<Set<string>>(new Set());
   const [options, setOptions] = useState<ChatOptions | null>(null);
   const [loadingSession, setLoadingSession] = useState(false);
   // Draft model+effort, used when no session is selected.
   const [draftModel, setDraftModel] = useState<string>("");
   const [draftEffort, setDraftEffort] = useState<string>("medium");
-  const abortRef = useRef<AbortController | null>(null);
+
+  // Sync mirror of activeId for SSE handlers running outside the render cycle.
+  const activeIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    activeIdRef.current = activeId;
+  }, [activeId]);
+
+  // Per-session AbortController so abort() and concurrent sends don't collide.
+  const controllersRef = useRef<Map<string, AbortController>>(new Map());
+
+  const streaming = activeId !== null && pendingSessions.has(activeId);
 
   const loadOptions = useCallback(async () => {
     const o = await getChatOptions();
@@ -45,17 +55,23 @@ export function useChatApp() {
   }, []);
 
   const newDraft = useCallback(() => {
-    if (abortRef.current) abortRef.current.abort();
     setActiveIdState(null);
     setActiveMeta(null);
     setItems([]);
   }, []);
 
   const selectSession = useCallback(async (id: string | null) => {
-    if (abortRef.current) abortRef.current.abort();
     setActiveIdState(id);
     setItems([]);
     setActiveMeta(null);
+    if (id) {
+      setUnreadSessions((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
     if (!id) return;
     setLoadingSession(true);
     try {
@@ -69,7 +85,16 @@ export function useChatApp() {
 
   const removeSession = useCallback(
     async (id: string) => {
+      const c = controllersRef.current.get(id);
+      if (c) c.abort();
+      controllersRef.current.delete(id);
       await deleteChatSession(id);
+      setUnreadSessions((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
       if (activeId === id) {
         setActiveIdState(null);
         setActiveMeta(null);
@@ -103,41 +128,48 @@ export function useChatApp() {
 
   const sendMessage = useCallback(
     async (content: string) => {
-      if (streaming) return;
+      // If the active session already has a pending stream, ignore.
+      if (activeId && pendingSessions.has(activeId)) return;
 
-      // Lazy create on first message in a draft
+      // Lazy create on first message in a draft.
       let currentId = activeId;
       let currentMeta = activeMeta;
       if (!currentId) {
         const meta = await createChatSession({ model: draftModel, effort: draftEffort });
         currentId = meta.id;
         currentMeta = meta;
-        setActiveIdState(meta.id);
-        setActiveMeta(meta);
+        // Only switch the user to the new session if they're still on the
+        // draft. If they navigated away during the create await, leave them
+        // alone — the new chat will appear in the sidebar via loadSessions.
+        if (activeIdRef.current === null) {
+          setActiveIdState(meta.id);
+          // Update the ref synchronously so the immediately-following
+          // foreground checks see the new session id without waiting on
+          // React's render cycle.
+          activeIdRef.current = meta.id;
+          setActiveMeta(meta);
+        }
+      }
+      const sessionId = currentId;
+
+      // Render user msg only if still on this chat.
+      if (sessionId === activeIdRef.current) {
+        setItems((prev) => [...prev, { role: "user", content }]);
       }
 
-      const userItem: ChatItem = { role: "user", content };
-      setItems((prev) => [...prev, userItem]);
-      setStreaming(true);
-
       const controller = new AbortController();
-      abortRef.current = controller;
+      controllersRef.current.set(sessionId, controller);
+      setPendingSessions((prev) => {
+        const next = new Set(prev);
+        next.add(sessionId);
+        return next;
+      });
 
-      // Stream every round's tokens into a *tentative* assistant bubble in
-      // `items` (rendered as a normal markdown bubble). round_end then either
-      // makes it permanent (final round) or removes it (prelude).
-      // Tentative bubbles carry a `round` field; permanent ones don't.
-      //
-      // These flags MUST live outside the setItems updater functions: React
-      // runs updaters during the render phase, not synchronously when called,
-      // so mutating a closure var inside an updater isn't visible to code
-      // running between SSE events. Tracking out here ensures the {final}
-      // backstop only fires when no streaming bubble was produced.
       let gotTokensForCurrentRound = false;
       let finalBubbleEmitted = false;
 
       try {
-        const res = await fetch(`${getServerUrl()}/api/chat/sessions/${currentId}/message`, {
+        const res = await fetch(`${getServerUrl()}/api/chat/sessions/${sessionId}/message`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ content }),
@@ -146,9 +178,15 @@ export function useChatApp() {
         if (!res.ok) {
           const text = await res.text();
           console.error("[chat] send failed:", text);
-          setStreaming(false);
           return;
         }
+
+        // Backend has already persisted the user message before the
+        // StreamingResponse returns, so message_count is now >= 1 and the
+        // new chat will pass the list_sessions filter. Refresh the sidebar
+        // immediately so the chat shows up as "New chat" right away even if
+        // the user has clicked away to another chat.
+        loadSessions();
 
         const reader = res.body!.getReader();
         const decoder = new TextDecoder();
@@ -165,46 +203,49 @@ export function useChatApp() {
             if (!line.startsWith("data: ")) continue;
             const data = JSON.parse(line.slice(6));
 
+            // Only mutate items if this stream is for the active chat.
+            const isForeground = sessionId === activeIdRef.current;
+
             if (typeof data.token === "string") {
-              const round = data.round ?? 0;
               gotTokensForCurrentRound = true;
-              setItems((prev) => {
-                const last = prev[prev.length - 1];
-                if (last && last.role === "assistant" && last.round === round) {
+              if (isForeground) {
+                const round = data.round ?? 0;
+                setItems((prev) => {
+                  const last = prev[prev.length - 1];
+                  if (last && last.role === "assistant" && last.round === round) {
+                    return [
+                      ...prev.slice(0, -1),
+                      { ...last, content: last.content + data.token },
+                    ];
+                  }
                   return [
-                    ...prev.slice(0, -1),
-                    { ...last, content: last.content + data.token },
+                    ...prev,
+                    { role: "assistant", content: data.token, round },
                   ];
-                }
-                return [
-                  ...prev,
-                  { role: "assistant", content: data.token, round },
-                ];
-              });
+                });
+              }
             }
 
             if (typeof data.round_end === "number") {
               const r = data.round_end;
               if (data.is_final) {
                 if (gotTokensForCurrentRound) {
-                  // Tentative bubble exists — promote (drop the round flag).
                   finalBubbleEmitted = true;
-                  setItems((prev) => {
-                    const last = prev[prev.length - 1];
-                    if (last && last.role === "assistant" && last.round === r) {
-                      return [
-                        ...prev.slice(0, -1),
-                        { role: "assistant", content: last.content },
-                      ];
-                    }
-                    return prev;
-                  });
+                  if (isForeground) {
+                    setItems((prev) => {
+                      const last = prev[prev.length - 1];
+                      if (last && last.role === "assistant" && last.round === r) {
+                        return [
+                          ...prev.slice(0, -1),
+                          { role: "assistant", content: last.content },
+                        ];
+                      }
+                      return prev;
+                    });
+                  }
                 }
-                // else: no tokens streamed for the final round; the {final}
-                // backstop below will provide the bubble.
-              } else {
-                // Prelude — drop the tentative bubble. The agent's narration
-                // (if any leaked through despite the prompt) was just status.
+              } else if (isForeground) {
+                // Prelude — drop the tentative bubble.
                 setItems((prev) => {
                   const last = prev[prev.length - 1];
                   if (last && last.role === "assistant" && last.round === r) {
@@ -217,23 +258,26 @@ export function useChatApp() {
             }
 
             if (typeof data.final === "string") {
-              // Backstop: if no streamed bubble was promoted (provider didn't
-              // emit deltas, agent hit max_rounds, etc.), surface final text.
               if (!finalBubbleEmitted && data.final.trim()) {
                 finalBubbleEmitted = true;
-                setItems((prev) => [
-                  ...prev,
-                  { role: "assistant", content: data.final },
-                ]);
+                if (isForeground) {
+                  setItems((prev) => [
+                    ...prev,
+                    { role: "assistant", content: data.final },
+                  ]);
+                }
               }
             }
 
-            if (typeof data.title === "string" && currentMeta) {
-              currentMeta = { ...currentMeta, title: data.title };
-              setActiveMeta(currentMeta);
+            if (typeof data.title === "string") {
+              if (sessionId === activeIdRef.current) {
+                setActiveMeta((prev) =>
+                  prev ? { ...prev, title: data.title } : prev,
+                );
+              }
             }
 
-            if (data.error) {
+            if (data.error && isForeground) {
               setItems((prev) => [
                 ...prev,
                 { role: "assistant", content: `**Error:** ${data.error}` },
@@ -245,28 +289,55 @@ export function useChatApp() {
         if (e instanceof Error && e.name === "AbortError") return;
         console.error("[chat] stream error:", e);
       } finally {
-        setStreaming(false);
-        abortRef.current = null;
+        controllersRef.current.delete(sessionId);
+        setPendingSessions((prev) => {
+          if (!prev.has(sessionId)) return prev;
+          const next = new Set(prev);
+          next.delete(sessionId);
+          return next;
+        });
         loadSessions();
+        if (sessionId === activeIdRef.current) {
+          // User is still here — refresh from disk and don't mark unread.
+          try {
+            const data = await getChatSession(sessionId);
+            setActiveMeta(data.meta);
+            setItems(data.messages);
+          } catch {
+            /* sidebar refresh already covers it */
+          }
+        } else {
+          // User navigated away — flag the chat as having a new response.
+          setUnreadSessions((prev) => {
+            const next = new Set(prev);
+            next.add(sessionId);
+            return next;
+          });
+        }
       }
+      void currentMeta;
     },
-    [activeId, activeMeta, streaming, draftModel, draftEffort, loadSessions],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeId, activeMeta, pendingSessions, draftModel, draftEffort, loadSessions],
   );
 
   const abort = useCallback(() => {
-    if (abortRef.current) abortRef.current.abort();
-    // Optimistically clear the chat activity so the sidebar pip and the
-    // inline progress banner disappear immediately. The backend will also
-    // broadcast a clear once its `finally` block runs, which is idempotent.
+    if (!activeId) return;
+    const c = controllersRef.current.get(activeId);
+    if (c) c.abort();
+    // Clear the activity pip immediately; backend will also clear on finally.
     dispatch({
       type: "AGENT_ACTIVITY",
       data: { agent: "chat", message: null },
     });
-  }, [dispatch]);
+  }, [activeId, dispatch]);
 
   useEffect(() => {
+    const controllers = controllersRef.current;
     return () => {
-      if (abortRef.current) abortRef.current.abort();
+      // Abort all pending streams on unmount.
+      controllers.forEach((c) => c.abort());
+      controllers.clear();
     };
   }, []);
 
@@ -276,6 +347,8 @@ export function useChatApp() {
     activeMeta,
     items,
     streaming,
+    pendingSessions,
+    unreadSessions,
     options,
     loadingSession,
     draftModel,

--- a/src/client/renderer/main.tsx
+++ b/src/client/renderer/main.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { AppProvider } from "./context/AppContext";
+import { ChatProvider } from "./context/ChatContext";
 import { App } from "./App";
 import "./styles/main.css";
 
 const root = document.getElementById("root")!;
 createRoot(root).render(
   <AppProvider>
-    <App />
+    <ChatProvider>
+      <App />
+    </ChatProvider>
   </AppProvider>
 );

--- a/src/client/renderer/styles/main.css
+++ b/src/client/renderer/styles/main.css
@@ -2780,14 +2780,28 @@ button, input, select, textarea, canvas, a, label,
   background: rgba(var(--sage-rgb), 0.12);
 }
 
+.chat-app-session-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-right: 18px;
+  min-width: 0;
+}
+
 .chat-app-session-title {
+  flex: 1;
   font-size: 12.5px;
   color: var(--text);
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding-right: 18px;
+  min-width: 0;
+}
+
+.chat-app-session-indicator {
+  flex-shrink: 0;
+  margin-left: 0;
 }
 
 .chat-app-session-meta {

--- a/src/client/shared/onboardingSteps.ts
+++ b/src/client/shared/onboardingSteps.ts
@@ -28,6 +28,7 @@ export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
   { id: "connectors",    type: "config" },
   { id: "models_keys",   type: "config" },
   { id: "tabracadabra",  type: "intro" },
+  { id: "chat",          type: "intro" },
   { id: "tadas",         type: "intro", flag: "moments" },
   { id: "memex",         type: "intro", flag: "memory"  },
 ];

--- a/tada-config.defaults.json
+++ b/tada-config.defaults.json
@@ -32,6 +32,6 @@
     "permission_system_audio": true,
 
     "permission_accessibility": true,
-    "permission_browser_cookies": false
+    "permission_browser_cookies": true
   }
 }


### PR DESCRIPTION
 - apps/chat/routes.py — save user message in the endpoint before streaming, so a quick send-then-switch survives.
  - apps/chat/service.py — filter [Compressed. Transcript: …] artifacts from visible_messages; export conversation.md per session.
  - hooks/useChatApp.ts — per-session concurrency: don't abort on switch, per-session pendingSessions / unreadSessions / AbortController map, foreground-gated token routing, immediate sidebar refresh on response start, reload-from-disk on completion, sync activeIdRef so
  the first user message renders.
  - views/ChatAppView.tsx — per-session unsent-text drafts; scroll instant on chat-load, smooth on stream; textarea stays editable while streaming (Send → Stop swap); revamped welcome screen with suggestion chips; per-row spinner / unread dot; styled effort dropdown.
  - styles/main.css — bigger center-aligned input, welcome visuals, traffic-light effort palette, markdown spacing fix.
  - Onboarding (new) — Onboarding.tsx + steps/ChatStep.tsx + steps/chatSample.ts + onboardingSteps.ts: scripted scrolling chat demo as a new onboarding step.